### PR TITLE
implement call instruction

### DIFF
--- a/test_framework/test_jit.py
+++ b/test_framework/test_jit.py
@@ -35,8 +35,13 @@ def check_datafile(filename):
         memfile.write(data['mem'])
         memfile.flush()
 
+    num_register_offsets = 20
+    if 'no register offset' in data:
+        # The JIT relies on a fixed register mapping for the call instruction
+        num_register_offsets = 1
+
     try:
-        for register_offset in xrange(0, 20):
+        for register_offset in xrange(0, num_register_offsets):
             cmd = [VM]
             if memfile:
                 cmd.extend(['-m', memfile.name])

--- a/tests/call-memfrob.data
+++ b/tests/call-memfrob.data
@@ -10,5 +10,5 @@ exit
 01 02 03 04 05 06 07 08
 -- result
 0x102292e2f2c0708
--- no jit
-CALL not yet implemented
+-- no register offset
+call instruction

--- a/tests/call-memfrob.data
+++ b/tests/call-memfrob.data
@@ -1,0 +1,14 @@
+-- asm
+mov r6, r1
+add r1, 2
+mov r2, 4
+call 1
+ldxdw r0, [r6]
+be64 r0
+exit
+-- mem
+01 02 03 04 05 06 07 08
+-- result
+0x102292e2f2c0708
+-- no jit
+CALL not yet implemented

--- a/tests/call-save.data
+++ b/tests/call-save.data
@@ -1,0 +1,16 @@
+-- asm
+mov r6, 0x0001
+mov r7, 0x0020
+mov r8, 0x0300
+mov r9, 0x4000
+call 2
+mov r0, 0
+or r0, r6
+or r0, r7
+or r0, r8
+or r0, r9
+exit
+-- result
+0x4321
+-- no register offset
+call instruction

--- a/tests/call.data
+++ b/tests/call.data
@@ -1,0 +1,12 @@
+-- asm
+mov r1, 1
+mov r2, 2
+mov r3, 3
+mov r4, 4
+mov r5, 5
+call 0
+exit
+-- result
+0x0102030405
+-- no jit
+CALL not yet implemented

--- a/tests/call.data
+++ b/tests/call.data
@@ -8,5 +8,5 @@ call 0
 exit
 -- result
 0x0102030405
--- no jit
-CALL not yet implemented
+-- no register offset
+call instruction

--- a/tests/err-call-bad-imm.data
+++ b/tests/err-call-bad-imm.data
@@ -1,0 +1,10 @@
+-- asm
+mov r1, 1
+mov r2, 2
+mov r3, 3
+mov r4, 4
+mov r5, 5
+call 64
+exit
+-- error
+Failed to load code: invalid call immediate at PC 5

--- a/tests/err-call-unreg.data
+++ b/tests/err-call-unreg.data
@@ -1,0 +1,10 @@
+-- asm
+mov r1, 1
+mov r2, 2
+mov r3, 3
+mov r4, 4
+mov r5, 5
+call 63
+exit
+-- error
+Failed to load code: call to nonexistent function 63 at PC 5

--- a/tests/err-div-by-zero-imm.data
+++ b/tests/err-div-by-zero-imm.data
@@ -3,4 +3,4 @@ mov32 r0, 1
 div32 r0, 0
 exit
 -- error
-Failed to create VM: division by zero at PC 1
+Failed to load code: division by zero at PC 1

--- a/tests/err-endian-size.data
+++ b/tests/err-endian-size.data
@@ -3,4 +3,4 @@
 0x00000000000010b7
 0x0000000000000095
 -- error
-Failed to create VM: invalid endian immediate at PC 0
+Failed to load code: invalid endian immediate at PC 0

--- a/tests/err-incomplete-lddw.data
+++ b/tests/err-incomplete-lddw.data
@@ -2,4 +2,4 @@
 0x5566778800000018
 0x0000000000000095
 -- error
-Failed to create VM: incomplete lddw at PC 0
+Failed to load code: incomplete lddw at PC 0

--- a/tests/err-incomplete-lddw2.data
+++ b/tests/err-incomplete-lddw2.data
@@ -2,4 +2,4 @@
 0x5566778800000018
 0x0000000000000095
 -- error
-Failed to create VM: incomplete lddw at PC 0
+Failed to load code: incomplete lddw at PC 0

--- a/tests/err-infinite-loop.data
+++ b/tests/err-infinite-loop.data
@@ -2,4 +2,4 @@
 ja -1
 exit
 -- error
-Failed to create VM: infinite loop at PC 0
+Failed to load code: infinite loop at PC 0

--- a/tests/err-invalid-reg-dst.data
+++ b/tests/err-invalid-reg-dst.data
@@ -2,4 +2,4 @@
 mov r11, 1
 exit
 -- error
-Failed to create VM: invalid destination register at PC 0
+Failed to load code: invalid destination register at PC 0

--- a/tests/err-invalid-reg-src.data
+++ b/tests/err-invalid-reg-src.data
@@ -2,4 +2,4 @@
 mov r0, r11
 exit
 -- error
-Failed to create VM: invalid source register at PC 0
+Failed to load code: invalid source register at PC 0

--- a/tests/err-jmp-lddw.data
+++ b/tests/err-jmp-lddw.data
@@ -3,4 +3,4 @@ ja +1
 lddw r0, 0x1122334455667788
 exit
 -- error
-Failed to create VM: jump to middle of lddw at PC 0
+Failed to load code: jump to middle of lddw at PC 0

--- a/tests/err-jmp-out.data
+++ b/tests/err-jmp-out.data
@@ -2,4 +2,4 @@
 ja +2
 exit
 -- error
-Failed to create VM: jump out of bounds at PC 0
+Failed to load code: jump out of bounds at PC 0

--- a/tests/err-noexit.data
+++ b/tests/err-noexit.data
@@ -1,4 +1,4 @@
 -- asm
 mov32 r0, 0
 -- error
-Failed to create VM: no exit at end of instructions
+Failed to load code: no exit at end of instructions

--- a/tests/err-too-many-instructions.data
+++ b/tests/err-too-many-instructions.data
@@ -65537,4 +65537,4 @@
 0x00000000000001b7
 0x0000000000000095
 -- error
-Failed to create VM: too many instructions (max 65536)
+Failed to load code: too many instructions (max 65536)

--- a/tests/err-unknown-opcode.data
+++ b/tests/err-unknown-opcode.data
@@ -2,4 +2,4 @@
 0x0000000000000006
 0x0000000000000095
 -- error
-Failed to create VM: unknown opcode 0x06 at PC 0
+Failed to load code: unknown opcode 0x06 at PC 0

--- a/tests/err-write-r10.dst
+++ b/tests/err-write-r10.dst
@@ -2,4 +2,4 @@
 mov r10, 1
 exit
 -- error
-Failed to create VM: invalid destination register at PC 0
+Failed to load code: invalid destination register at PC 0

--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -26,9 +26,23 @@ struct ubpf_vm *ubpf_create(void);
 void ubpf_destroy(struct ubpf_vm *vm);
 
 /*
+ * Register an external function
+ *
+ * The immediate field of a CALL instruction is an index into an array of
+ * functions registered by the user. This API associates a function with
+ * an index.
+ *
+ * 'name' should be a string with a lifetime longer than the VM.
+ *
+ * Returns 0 on success, -1 on error.
+ */
+int ubpf_register(struct ubpf_vm *vm, unsigned int idx, const char *name, void *fn);
+
+/*
  * Load code into a VM
  *
- * This must be done before calling ubpf_exec or ubpf_compile.
+ * This must be done before calling ubpf_exec or ubpf_compile and after
+ * registering all functions.
  *
  * 'code' should point to eBPF bytecodes and 'code_len' should be the size in
  * bytes of that buffer.

--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -22,8 +22,21 @@
 struct ubpf_vm;
 typedef uint64_t (*ubpf_jit_fn)(void *mem, size_t mem_len);
 
-struct ubpf_vm *ubpf_create(const void *code, uint32_t code_len, char **errmsg);
+struct ubpf_vm *ubpf_create(void);
 void ubpf_destroy(struct ubpf_vm *vm);
+
+/*
+ * Load code into a VM
+ *
+ * This must be done before calling ubpf_exec or ubpf_compile.
+ *
+ * 'code' should point to eBPF bytecodes and 'code_len' should be the size in
+ * bytes of that buffer.
+ *
+ * Returns 0 on success, -1 on error. In case of error a pointer to the error
+ * message will be stored in 'errmsg' and should be freed by the caller.
+ */
+int ubpf_load(struct ubpf_vm *vm, const void *code, uint32_t code_len, char **errmsg);
 
 uint64_t ubpf_exec(const struct ubpf_vm *vm, void *mem, size_t mem_len);
 

--- a/vm/test.c
+++ b/vm/test.c
@@ -91,10 +91,15 @@ int main(int argc, char **argv)
         }
     }
 
+    struct ubpf_vm *vm = ubpf_create();
+    if (!vm) {
+        fprintf(stderr, "Failed to create VM\n");
+        return 1;
+    }
+
     char *errmsg;
-    struct ubpf_vm *vm = ubpf_create(code, code_len, &errmsg);
-    if (vm == NULL) {
-        fprintf(stderr, "Failed to create VM: %s\n", errmsg);
+    if (ubpf_load(vm, code, code_len, &errmsg) < 0) {
+        fprintf(stderr, "Failed to load code: %s\n", errmsg);
         free(errmsg);
         return 1;
     }

--- a/vm/test.c
+++ b/vm/test.c
@@ -183,8 +183,26 @@ gather_bytes(uint8_t a, uint8_t b, uint8_t c, uint8_t d, uint8_t e)
 }
 
 static void
+trash_registers(void)
+{
+    /* Overwrite all caller-save registers */
+    asm(
+        "mov $0xf0, %rax;"
+        "mov $0xf1, %rcx;"
+        "mov $0xf2, %rdx;"
+        "mov $0xf3, %rsi;"
+        "mov $0xf4, %rdi;"
+        "mov $0xf5, %r8;"
+        "mov $0xf6, %r9;"
+        "mov $0xf7, %r10;"
+        "mov $0xf8, %r11;"
+    );
+}
+
+static void
 register_functions(struct ubpf_vm *vm)
 {
     ubpf_register(vm, 0, "gather_bytes", gather_bytes);
     ubpf_register(vm, 1, "memfrob", memfrob);
+    ubpf_register(vm, 2, "trash_registers", trash_registers);
 }

--- a/vm/test.c
+++ b/vm/test.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#define _GNU_SOURCE
 #include <inttypes.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -26,6 +27,7 @@
 
 void ubpf_set_register_offset(int x);
 static void *readfile(const char *path, size_t maxlen, size_t *len);
+static void register_functions(struct ubpf_vm *vm);
 
 static void usage(const char *name)
 {
@@ -97,6 +99,8 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    register_functions(vm);
+
     char *errmsg;
     if (ubpf_load(vm, code, code_len, &errmsg) < 0) {
         fprintf(stderr, "Failed to load code: %s\n", errmsg);
@@ -166,4 +170,21 @@ static void *readfile(const char *path, size_t maxlen, size_t *len)
         *len = offset;
     }
     return data;
+}
+
+static uint64_t
+gather_bytes(uint8_t a, uint8_t b, uint8_t c, uint8_t d, uint8_t e)
+{
+    return ((uint64_t)a << 32) |
+        ((uint32_t)b << 24) |
+        ((uint32_t)c << 16) |
+        ((uint16_t)d << 8) |
+        e;
+}
+
+static void
+register_functions(struct ubpf_vm *vm)
+{
+    ubpf_register(vm, 0, "gather_bytes", gather_bytes);
+    ubpf_register(vm, 1, "memfrob", memfrob);
 }

--- a/vm/ubpf_int.h
+++ b/vm/ubpf_int.h
@@ -21,12 +21,15 @@
 #include "ebpf.h"
 
 struct ebpf_inst;
+typedef uint64_t (*ext_func)(uint64_t arg0, uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4);
 
 struct ubpf_vm {
     struct ebpf_inst *insts;
     uint16_t num_insts;
     ubpf_jit_fn jitted;
     size_t jitted_size;
+    ext_func *ext_funcs;
+    const char **ext_func_names;
 };
 
 char *ubpf_error(const char *fmt, ...);

--- a/vm/ubpf_jit.dasm
+++ b/vm/ubpf_jit.dasm
@@ -141,6 +141,11 @@ ubpf_compile(struct ubpf_vm *vm, char **errmsg)
         return vm->jitted;
     }
 
+    if (!vm->insts) {
+        *errmsg = ubpf_error("code has not been loaded into this VM");
+        return NULL;
+    }
+
     |.section code
     dasm_init(&d, DASM_MAXSECTION);
 

--- a/vm/ubpf_jit.dasm
+++ b/vm/ubpf_jit.dasm
@@ -422,6 +422,20 @@ ubpf_compile(struct ubpf_vm *vm, char **errmsg)
             | cmp Rq(dst), Rq(src)
             | jge =>jmp_target
             break;
+        case EBPF_OP_CALL:
+            /* TODO use callee save registers for these */
+            | push r10
+            | push r11
+            /* TODO fix register assignment */
+            | mov rcx, r8
+            | mov r8, r9
+            /* TODO direct call */
+            | mov rax, vm->ext_funcs[inst.imm]
+            | call rax
+            /* TODO use callee save registers for these */
+            | pop r11
+            | pop r10
+            break;
         case EBPF_OP_EXIT:
             if (i != vm->num_insts - 1) {
                 | jmp ->exit

--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -26,14 +26,32 @@
 
 #define MAX_INSTS 65536
 #define STACK_SIZE 128
+#define MAX_EXT_FUNCS 64
 
-static bool validate(const struct ebpf_inst *insts, uint32_t num_insts, char **errmsg);
+static bool validate(const struct ubpf_vm *vm, const struct ebpf_inst *insts, uint32_t num_insts, char **errmsg);
 static bool bounds_check(void *addr, int size, const char *type, uint16_t cur_pc, void *mem, size_t mem_len, void *stack);
 
 struct ubpf_vm *
 ubpf_create(void)
 {
-    return calloc(1, sizeof(struct ubpf_vm));
+    struct ubpf_vm *vm = calloc(1, sizeof(*vm));
+    if (vm == NULL) {
+        return NULL;
+    }
+
+    vm->ext_funcs = calloc(MAX_EXT_FUNCS, sizeof(*vm->ext_funcs));
+    if (vm->ext_funcs == NULL) {
+        ubpf_destroy(vm);
+        return NULL;
+    }
+
+    vm->ext_func_names = calloc(MAX_EXT_FUNCS, sizeof(*vm->ext_func_names));
+    if (vm->ext_func_names == NULL) {
+        ubpf_destroy(vm);
+        return NULL;
+    }
+
+    return vm;
 }
 
 void
@@ -43,7 +61,21 @@ ubpf_destroy(struct ubpf_vm *vm)
         munmap(vm->jitted, vm->jitted_size);
     }
     free(vm->insts);
+    free(vm->ext_funcs);
+    free(vm->ext_func_names);
     free(vm);
+}
+
+int
+ubpf_register(struct ubpf_vm *vm, unsigned int idx, const char *name, void *fn)
+{
+    if (idx >= MAX_EXT_FUNCS) {
+        return -1;
+    }
+
+    vm->ext_funcs[idx] = (ext_func)fn;
+    vm->ext_func_names[idx] = name;
+    return 0;
 }
 
 int
@@ -61,7 +93,7 @@ ubpf_load(struct ubpf_vm *vm, const void *code, uint32_t code_len, char **errmsg
         return -1;
     }
 
-    if (!validate(code, code_len/8, errmsg)) {
+    if (!validate(vm, code, code_len/8, errmsg)) {
         return -1;
     }
 
@@ -464,14 +496,15 @@ ubpf_exec(const struct ubpf_vm *vm, void *mem, size_t mem_len)
             break;
         case EBPF_OP_EXIT:
             return reg[0];
-
-        /* TODO CALL opcode */
+        case EBPF_OP_CALL:
+            reg[0] = vm->ext_funcs[inst.imm](reg[1], reg[2], reg[3], reg[4], reg[5]);
+            break;
         }
     }
 }
 
 static bool
-validate(const struct ebpf_inst *insts, uint32_t num_insts, char **errmsg)
+validate(const struct ubpf_vm *vm, const struct ebpf_inst *insts, uint32_t num_insts, char **errmsg)
 {
     if (num_insts >= MAX_INSTS) {
         *errmsg = ubpf_error("too many instructions (max %u)", MAX_INSTS);
@@ -597,6 +630,17 @@ validate(const struct ebpf_inst *insts, uint32_t num_insts, char **errmsg)
                 return false;
             } else if (insts[new_pc].opcode == 0) {
                 *errmsg = ubpf_error("jump to middle of lddw at PC %d", i);
+                return false;
+            }
+            break;
+
+        case EBPF_OP_CALL:
+            if (inst.imm < 0 || inst.imm >= MAX_EXT_FUNCS) {
+                *errmsg = ubpf_error("invalid call immediate at PC %d", i);
+                return false;
+            }
+            if (!vm->ext_funcs[inst.imm]) {
+                *errmsg = ubpf_error("call to nonexistent function %u at PC %d", inst.imm, i);
                 return false;
             }
             break;


### PR DESCRIPTION
The application can register functions for the eBPF program to call. These are
named by the small integer index that goes in the call immediate.

In the near future I'll add an ELF loader that "relocates" call instructions,
inserting the called function's index into the bytecode after looking it up by
name.