### PR TITLE
basic ELF loader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ script:
   - make -C vm COVERAGE=1
   - nosetests -v
 after_success:
-  - coveralls --gcov-options '\-lp' -i $PWD/vm/ubpf_vm.c -i $PWD/vm/ubpf_jit.dasm
+  - coveralls --gcov-options '\-lp' -i $PWD/vm/ubpf_vm.c -i $PWD/vm/ubpf_jit.dasm -i $PWD/vm/ubpf_loader.c

--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ and a simple executable used by the testsuite.
 You'll need [Clang 3.7] (http://llvm.org/releases/download.html#3.7.0).
 
     clang-3.7 -O2 -target bpf -c prog.c -o prog.o
-    objcopy -I elf64-little -O binary prog.o prog.bin
 
-You can then pass the contents of `prog.bin` to `ubpf_create`, or to the stdin of
+You can then pass the contents of `prog.o` to `ubpf_load_elf`, or to the stdin of
 the `vm/test` binary.
 
 ## Contributing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 parcon ~= 0.1.25
 nose ~= 1.3.1
+pyelftools ~= 0.23

--- a/test_framework/test_elf.py
+++ b/test_framework/test_elf.py
@@ -1,0 +1,161 @@
+import sys
+import os
+import tempfile
+import struct
+import re
+import elftools.elf.structs
+from subprocess import Popen, PIPE
+from nose.plugins.skip import Skip, SkipTest
+from elftools.construct import Container
+from elftools.elf.constants import SH_FLAGS
+import testdata
+VM = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "vm", "test")
+
+def template():
+    parts = {}
+    parts['order'] = []
+    def add(name, value):
+        parts[name] = value
+        parts['order'].append(name)
+
+    add('ehdr', Container(
+        e_ident=Container(
+            EI_MAG=[0x7f, ord('E'), ord('L'), ord('F')],
+            EI_CLASS='ELFCLASS64',
+            EI_DATA='ELFDATA2LSB',
+            EI_VERSION='EV_CURRENT',
+            EI_OSABI='ELFOSABI_SYSV',
+            EI_ABIVERSION=0),
+        e_type='ET_REL',
+        e_machine='EM_NONE',
+        e_version=0,
+        e_entry=0,
+        e_phoff=0,
+        e_shoff=64,
+        e_flags=0,
+        e_ehsize=64,
+        e_phentsize=0,
+        e_phnum=0,
+        e_shentsize=64,
+        e_shnum=4,
+        e_shstrndx=2))
+
+    add('first_shdr', Container(
+        sh_name=0,
+        sh_type='SHT_NULL',
+        sh_flags=0,
+        sh_addr=0,
+        sh_offset=0,
+        sh_size=0,
+        sh_link=0,
+        sh_info=0,
+        sh_addralign=0,
+        sh_entsize=0))
+
+    add('text_shdr', Container(
+        sh_name=1,
+        sh_type='SHT_PROGBITS',
+        sh_flags=SH_FLAGS.SHF_ALLOC|SH_FLAGS.SHF_EXECINSTR,
+        sh_addr=0,
+        sh_offset=320,
+        sh_size=16,
+        sh_link=0,
+        sh_info=0,
+        sh_addralign=8,
+        sh_entsize=0))
+
+    add('strtab_shdr', Container(
+        sh_name=7,
+        sh_type='SHT_STRTAB',
+        sh_flags=0,
+        sh_addr=0,
+        sh_offset=336,
+        sh_size=23,
+        sh_link=0,
+        sh_info=0,
+        sh_addralign=1,
+        sh_entsize=0))
+
+    add('symtab_shdr', Container(
+        sh_name=15,
+        sh_type='SHT_SYMTAB',
+        sh_flags=0,
+        sh_addr=0,
+        sh_offset=359,
+        sh_size=0,
+        sh_link=0,
+        sh_info=0,
+        sh_addralign=8,
+        sh_entsize=24))
+
+    add("text", "\xb7\x00\x00\x00\x2a\x00\x00\x00\x95\x00\x00\x00\x00\x00\x00\x00")
+    add("strtab", "\0.text\0.strtab\0.symtab\0")
+    add("symtab", "")
+
+    return parts
+
+def serialize(parts):
+    s = elftools.elf.structs.ELFStructs(elfclass=64)
+    tmp = []
+
+    for name in parts['order']:
+        part = parts[name]
+        serializer = str
+        if name == 'ehdr':
+            serializer = s.Elf_Ehdr.build
+        elif name.endswith('shdr'):
+            serializer = s.Elf_Shdr.build
+        tmp.append(serializer(part))
+
+    return ''.join(tmp)
+
+def check_datafile(filename):
+    """
+    """
+    data = testdata.read(filename)
+    if 'pyelf' not in data:
+        raise SkipTest("no pyelf section in datafile")
+    if 'result' not in data and 'error' not in data and 'error pattern' not in data:
+        raise SkipTest("no result or error section in datafile")
+    if not os.path.exists(VM):
+        raise SkipTest("VM not found")
+
+    parts = template()
+    exec(data['pyelf'], parts)
+    elf = serialize(parts)
+
+    cmd = [VM]
+
+    cmd.append('-')
+
+    vm = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+
+    stdout, stderr = vm.communicate(elf)
+    stderr = stderr.strip()
+
+    if 'error' in data:
+        if data['error'] != stderr:
+            raise AssertionError("Expected error %r, got %r" % (data['error'], stderr))
+    elif 'error pattern' in data:
+        if not re.search(data['error pattern'], stderr):
+            raise AssertionError("Expected error matching %r, got %r" % (data['error pattern'], stderr))
+    else:
+        if stderr:
+            raise AssertionError("Unexpected error %r" % stderr)
+
+    if 'result' in data:
+        if vm.returncode != 0:
+            raise AssertionError("VM exited with status %d, stderr=%r" % (vm.returncode, stderr))
+        expected = int(data['result'], 0)
+        result = int(stdout, 0)
+        if expected != result:
+            raise AssertionError("Expected result 0x%x, got 0x%x, stderr=%r" % (expected, result, stderr))
+    else:
+        if vm.returncode == 0:
+            raise AssertionError("Expected VM to exit with an error code")
+
+def test_datafiles():
+    # Nose test generator
+    # Creates a testcase for each datafile
+    for filename in testdata.list_files():
+        yield check_datafile, filename

--- a/tests/elf/bad-section-header-offset.data
+++ b/tests/elf/bad-section-header-offset.data
@@ -1,0 +1,4 @@
+-- pyelf
+ehdr.e_shoff = 1024
+-- error
+Failed to load code: bad section header offset or size

--- a/tests/elf/bad-section-header-size.data
+++ b/tests/elf/bad-section-header-size.data
@@ -1,0 +1,4 @@
+-- pyelf
+ehdr.e_shnum = 1024
+-- error
+Failed to load code: bad section header offset or size

--- a/tests/elf/bad-section-offset.data
+++ b/tests/elf/bad-section-offset.data
@@ -1,0 +1,4 @@
+-- pyelf
+text_shdr.sh_offset = 1024
+-- error
+Failed to load code: bad section offset or size

--- a/tests/elf/bad-section-size.data
+++ b/tests/elf/bad-section-size.data
@@ -1,0 +1,4 @@
+-- pyelf
+text_shdr.sh_size = 1024
+-- error
+Failed to load code: bad section offset or size

--- a/tests/elf/ehdr-short.data
+++ b/tests/elf/ehdr-short.data
@@ -1,0 +1,6 @@
+-- pyelf
+del order[:]
+magic = '\x7fELF'
+order.append('magic')
+-- error
+Failed to load code: not enough data for ELF header

--- a/tests/elf/no-text-section.data
+++ b/tests/elf/no-text-section.data
@@ -1,0 +1,4 @@
+-- pyelf
+text_shdr.sh_type = 'SHT_NULL'
+-- error
+Failed to load code: text section not found

--- a/tests/elf/ok.data
+++ b/tests/elf/ok.data
@@ -1,0 +1,3 @@
+-- pyelf
+-- result
+0x2a

--- a/tests/elf/rel-section.data
+++ b/tests/elf/rel-section.data
@@ -1,0 +1,4 @@
+-- pyelf
+symtab_shdr.sh_type = 'SHT_REL'
+-- error
+Failed to load code: rel section found but not supported

--- a/tests/elf/wrong-byte-order.data
+++ b/tests/elf/wrong-byte-order.data
@@ -1,0 +1,4 @@
+-- pyelf
+ehdr.e_ident.EI_DATA = 'ELFDATA2MSB'
+-- error
+Failed to load code: wrong byte order

--- a/tests/elf/wrong-class.data
+++ b/tests/elf/wrong-class.data
@@ -1,0 +1,4 @@
+-- pyelf
+ehdr.e_ident.EI_CLASS = 'ELFCLASS32'
+-- error
+Failed to load code: wrong class

--- a/tests/elf/wrong-machine.data
+++ b/tests/elf/wrong-machine.data
@@ -1,0 +1,4 @@
+-- pyelf
+ehdr.e_machine = 1
+-- error
+Failed to load code: wrong machine, expected none

--- a/tests/elf/wrong-osabi.data
+++ b/tests/elf/wrong-osabi.data
@@ -1,0 +1,4 @@
+-- pyelf
+ehdr.e_ident.EI_OSABI = 'ELFOSABI_LINUX'
+-- error
+Failed to load code: wrong OS ABI

--- a/tests/elf/wrong-type.data
+++ b/tests/elf/wrong-type.data
@@ -1,0 +1,4 @@
+-- pyelf
+ehdr.e_type = 0
+-- error
+Failed to load code: wrong type, expected relocatable

--- a/tests/elf/wrong-version.data
+++ b/tests/elf/wrong-version.data
@@ -1,0 +1,4 @@
+-- pyelf
+ehdr.e_ident.EI_VERSION = 2
+-- error
+Failed to load code: wrong version

--- a/vm/Makefile
+++ b/vm/Makefile
@@ -27,7 +27,7 @@ all: libubpf.a test
 %.c: %.dasm minilua
 	LUA_PATH=$(DYNASM)/?.lua ./minilua $(DYNASM)/dynasm.lua -o $@ $<
 
-libubpf.a: ubpf_vm.o ubpf_jit.o
+libubpf.a: ubpf_vm.o ubpf_jit.o ubpf_loader.o
 	ar rc $@ $^
 
 test: test.o libubpf.a

--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -52,6 +52,24 @@ int ubpf_register(struct ubpf_vm *vm, unsigned int idx, const char *name, void *
  */
 int ubpf_load(struct ubpf_vm *vm, const void *code, uint32_t code_len, char **errmsg);
 
+/*
+ * Load code from an ELF file
+ *
+ * This must be done before calling ubpf_exec or ubpf_compile and after
+ * registering all functions.
+ *
+ * 'elf' should point to a copy of an ELF file in memory and 'elf_len' should
+ * be the size in bytes of that buffer.
+ *
+ * The ELF file must be 64-bit little-endian with a single text section
+ * containing the eBPF bytecodes. This is compatible with the output of
+ * Clang.
+ *
+ * Returns 0 on success, -1 on error. In case of error a pointer to the error
+ * message will be stored in 'errmsg' and should be freed by the caller.
+ */
+int ubpf_load_elf(struct ubpf_vm *vm, const void *elf, size_t elf_len, char **errmsg);
+
 uint64_t ubpf_exec(const struct ubpf_vm *vm, void *mem, size_t mem_len);
 
 ubpf_jit_fn ubpf_compile(struct ubpf_vm *vm, char **errmsg);

--- a/vm/test.c
+++ b/vm/test.c
@@ -139,7 +139,7 @@ static void *readfile(const char *path, size_t maxlen, size_t *len)
     }
 
     if (file == NULL) {
-        fprintf(stderr, "Failed to open %s: %s", path, strerror(errno));
+        fprintf(stderr, "Failed to open %s: %s\n", path, strerror(errno));
         return NULL;
     }
 
@@ -151,7 +151,7 @@ static void *readfile(const char *path, size_t maxlen, size_t *len)
     }
 
     if (ferror(file)) {
-        fprintf(stderr, "Failed to read %s: %s", path, strerror(errno));
+        fprintf(stderr, "Failed to read %s: %s\n", path, strerror(errno));
         fclose(file);
         free(data);
         return NULL;

--- a/vm/ubpf_loader.c
+++ b/vm/ubpf_loader.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2015 Big Switch Networks, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <inttypes.h>
+#include "ubpf_int.h"
+#include <elf.h>
+
+int
+ubpf_load_elf(struct ubpf_vm *vm, const void *elf, size_t elf_size, char **errmsg)
+{
+    const Elf64_Ehdr *ehdr = elf;
+
+    if (elf_size < sizeof(*ehdr)) {
+        *errmsg = ubpf_error("not enough data for ELF header");
+        goto error;
+    }
+
+    if (memcmp(ehdr->e_ident, ELFMAG, SELFMAG)) {
+        *errmsg = ubpf_error("wrong magic");
+        goto error;
+    }
+
+    if (ehdr->e_ident[EI_CLASS] != ELFCLASS64) {
+        *errmsg = ubpf_error("wrong class");
+        goto error;
+    }
+
+    if (ehdr->e_ident[EI_DATA] != ELFDATA2LSB) {
+        *errmsg = ubpf_error("wrong byte order");
+        goto error;
+    }
+
+    if (ehdr->e_ident[EI_VERSION] != 1) {
+        *errmsg = ubpf_error("wrong version");
+        goto error;
+    }
+
+    if (ehdr->e_ident[EI_OSABI] != ELFOSABI_NONE) {
+        *errmsg = ubpf_error("wrong OS ABI");
+        goto error;
+    }
+
+    if (ehdr->e_type != ET_REL) {
+        *errmsg = ubpf_error("wrong type, expected relocatable");
+        goto error;
+    }
+
+    if (ehdr->e_machine != EM_NONE) {
+        *errmsg = ubpf_error("wrong machine, expected none");
+        goto error;
+    }
+
+    if (ehdr->e_shoff == 0 || ehdr->e_shoff + ehdr->e_shentsize * ehdr->e_shnum > elf_size || ehdr->e_shoff + ehdr->e_shentsize * ehdr->e_shnum < ehdr->e_shoff) {
+        *errmsg = ubpf_error("bad section header offset or size");
+        goto error;
+    }
+
+    const Elf64_Shdr *text_shdr = NULL;
+
+    const Elf64_Shdr *shdr = elf + ehdr->e_shoff;
+    int i;
+    for (i = 0; i < ehdr->e_shnum; i++) {
+        if (shdr->sh_offset + shdr->sh_size > elf_size ||
+                shdr->sh_offset + shdr->sh_size < shdr->sh_offset) {
+            *errmsg = ubpf_error("bad section offset or size");
+            goto error;
+        }
+
+        if (shdr->sh_type == SHT_PROGBITS &&
+                shdr->sh_flags == (SHF_ALLOC|SHF_EXECINSTR)) {
+            text_shdr = shdr;
+        } else if (shdr->sh_type == SHT_REL) {
+            *errmsg = ubpf_error("rel section found but not supported");
+            goto error;
+        }
+
+        shdr = (void *)shdr + ehdr->e_shentsize;
+    }
+
+    if (!text_shdr) {
+        *errmsg = ubpf_error("text section not found");
+        goto error;
+    }
+
+    return ubpf_load(vm, elf + text_shdr->sh_offset, text_shdr->sh_size, errmsg);
+
+error:
+    return -1;
+}


### PR DESCRIPTION
This simplifies running programs compiled by Clang because the user doesn't
need to extract the eBPF instructions from the object file. In the future
we'll use ELF to carry more information, such as function call relocations
and maps.