### PR TITLE
Save the stack pointer before allocating new stack space, fix #9

### DIFF
--- a/vm/ubpf_jit_x86_64.c
+++ b/vm/ubpf_jit_x86_64.c
@@ -92,11 +92,11 @@ translate(struct ubpf_vm *vm, struct jit_state *state, char **errmsg)
         emit_mov(state, RDI, map_register(1));
     }
 
-    /* Allocate stack space */
-    emit_alu64_imm32(state, 0x81, 5, RSP, STACK_SIZE);
-
     /* Copy stack pointer to R10 */
     emit_mov(state, RSP, map_register(10));
+
+    /* Allocate stack space */
+    emit_alu64_imm32(state, 0x81, 5, RSP, STACK_SIZE);
 
     int i;
     for (i = 0; i < vm->num_insts; i++) {


### PR DESCRIPTION
As described in #9 there is a problem with the saving the reference to the stack after the allocation.

The stack allocation (see below) will allocate the stack space but also modify the stack pointer to the top of the newly allocated stack space.

```
    /* Allocate stack space */
    emit_alu64_imm32(state, 0x81, 5, RSP, STACK_SIZE);
```

Therefore the code must be changed to first save the stack pointer to R10 and then be allocated in order to have R10 to point to the bottom of the stack.