### PR TITLE
initialize R2 with data length

### DIFF
--- a/vm/ubpf_jit_x86_64.c
+++ b/vm/ubpf_jit_x86_64.c
@@ -93,6 +93,11 @@ translate(struct ubpf_vm *vm, struct jit_state *state, char **errmsg)
         emit_mov(state, RDI, map_register(1));
     }
 
+    /* Move rsi into register 2 */
+    if (map_register(2) != RSI) {
+        emit_mov(state, RSI, map_register(2));
+    }
+
     /* Copy stack pointer to R10 */
     emit_mov(state, RSP, map_register(10));
 

--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -140,6 +140,7 @@ ubpf_exec(const struct ubpf_vm *vm, void *mem, size_t mem_len)
     }
 
     reg[1] = (uintptr_t)mem;
+    reg[2] = (uint64_t)mem_len;
     reg[10] = (uintptr_t)stack + sizeof(stack);
 
     while (1) {


### PR DESCRIPTION
It is convenient to know data size immediately, without going through indirect structure. What do you think?