### PR TITLE
Fix tests for new pyelftools version

### DIFF
--- a/test_framework/test_elf.py
+++ b/test_framework/test_elf.py
@@ -136,6 +136,9 @@ exit
 
 def serialize(parts):
     s = elftools.elf.structs.ELFStructs(elfclass=64)
+    s.create_basic_structs()
+    ehdr = parts['ehdr']
+    s.create_advanced_structs(ehdr['e_type'], ehdr['e_machine'], ehdr['e_ident']['EI_OSABI'])
     tmp = []
     offset = 0
 


### PR DESCRIPTION
With the last pyelftools version, ELFStructs' attributes now need to be explicitly initialized.

This pull request thereby fixes the Travis CI builds.