### PR TITLE
Negative jump offsets are valid in eBPF

### DIFF
--- a/tests/err-noexit.data
+++ b/tests/err-noexit.data
@@ -1,4 +1,0 @@
--- asm
-mov32 r0, 0
--- error
-Failed to load code: no exit at end of instructions

--- a/tests/exit-not-last.data
+++ b/tests/exit-not-last.data
@@ -1,0 +1,9 @@
+-- asm
+mov r1, 0
+ja +2
+mov r2, 0
+exit
+mov r0, 0
+ja -4
+-- result
+0x0

--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -562,11 +562,6 @@ validate(const struct ubpf_vm *vm, const struct ebpf_inst *insts, uint32_t num_i
         return false;
     }
 
-    if (num_insts == 0 || insts[num_insts-1].opcode != EBPF_OP_EXIT) {
-        *errmsg = ubpf_error("no exit at end of instructions");
-        return false;
-    }
-
     int i;
     for (i = 0; i < num_insts; i++) {
         struct ebpf_inst inst = insts[i];


### PR DESCRIPTION
Negative jump offsets are valid in eBPF. Thus, while all paths through the CFG should end with an exit instruction, it is not necessarily the last instruction.