### PR TITLE
Update verifier's constant to match kernel's

### DIFF
--- a/vm/ubpf_int.h
+++ b/vm/ubpf_int.h
@@ -20,8 +20,8 @@
 #include <ubpf.h>
 #include "ebpf.h"
 
-#define MAX_INSTS 65536
-#define STACK_SIZE 128
+#define MAX_INSTS 4096
+#define STACK_SIZE 512
 
 struct ebpf_inst;
 typedef uint64_t (*ext_func)(uint64_t arg0, uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4);


### PR DESCRIPTION
In the kernel, the stack can be as large as [512B](https://elixir.bootlin.com/linux/v4.19.13/source/include/linux/filter.h#L78), but programs are limited to a maximum of [4096](https://elixir.bootlin.com/linux/v4.19.13/source/include/uapi/linux/bpf_common.h#L54) instructions.