### PR TITLE
vm/Makefile: Add an install target

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ and JIT compiler for x86-64.
 ## Building
 
 Run `make -C vm` to build the VM. This produces a static library `libubpf.a`
-and a simple executable used by the testsuite.
+and a simple executable used by the testsuite. After building the
+library you can install using `make -C vm install` via either root or
+sudo.
 
 ## Compiling C to eBPF
 

--- a/vm/Makefile
+++ b/vm/Makefile
@@ -15,6 +15,10 @@
 CFLAGS := -Wall -Werror -Iinc -O2 -g
 LDLIBS := -lm
 
+INSTALL ?= install
+DESTDIR =
+PREFIX ?= /usr/local
+
 ifeq ($(COVERAGE),1)
 CFLAGS += -fprofile-arcs -ftest-coverage
 LDFLAGS += -fprofile-arcs
@@ -33,6 +37,12 @@ libubpf.a: ubpf_vm.o ubpf_jit_x86_64.o ubpf_loader.o
 	ar rc $@ $^
 
 test: test.o libubpf.a
+
+install:
+	$(INSTALL) -d $(DESTDIR)$(PREFIX)/lib
+	$(INSTALL) -m 644 libubpf.a $(DESTDIR)$(PREFIX)/lib
+	$(INSTALL) -d $(DESTDIR)$(PREFIX)/include
+	$(INSTALL) -m 644 inc/ubpf.h $(DESTDIR)$(PREFIX)/include
 
 clean:
 	rm -f test libubpf.a *.o


### PR DESCRIPTION
In order to use the ubpf static library in other applications it is
useful to have a "make install" target. We place the relevent files
(libubpf.a and ubpf.h) into the /usr/local tree at the right spots to
allow other programs to reference them.

Signed-off-by: Stephen Bates <sbates@raithlin.com>