### PR TITLE
Expose VM registers

### DIFF
--- a/vm/Makefile
+++ b/vm/Makefile
@@ -29,6 +29,10 @@ CFLAGS += -fsanitize=address
 LDFLAGS += -fsanitize=address
 endif
 
+ifeq ($(DEBUG),1)
+CFLAGS += -DDEBUG
+endif
+
 all: libubpf.a libubpf.so test
 
 ubpf_jit_x86_64.o: ubpf_jit_x86_64.c ubpf_jit_x86_64.h

--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -134,4 +134,7 @@ int ubpf_translate(struct ubpf_vm *vm, uint8_t *buffer, size_t *size, char **err
  */
 int ubpf_set_unwind_function_index(struct ubpf_vm *vm, unsigned int idx);
 
+void ubpf_set_registers(struct ubpf_vm *vm, uint64_t *regs);
+uint64_t *ubpf_get_registers(const struct ubpf_vm *vm);
+
 #endif

--- a/vm/ubpf_int.h
+++ b/vm/ubpf_int.h
@@ -35,6 +35,9 @@ struct ubpf_vm {
     int (*error_printf)(FILE* stream, const char* format, ...);
     int (*translate)(struct ubpf_vm *vm, uint8_t *buffer, size_t *size, char **errmsg);
     int unwind_stack_extension_index;
+#ifdef DEBUG
+    uint64_t *regs;
+#endif
 };
 
 /* The various JIT targets.  */


### PR DESCRIPTION
There are two different contributions in this PR. I can create two different PRs if needed.

The first one adds an install target to Makefile that places the static library + header in /usr/local.

The second exposes the VM registers to the user.