### PR TITLE
Introduce toggle to enable/disable bounds_check.

### DIFF
--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -27,6 +27,15 @@ struct ubpf_vm *ubpf_create(void);
 void ubpf_destroy(struct ubpf_vm *vm);
 
 /*
+ * Enable / disable bounds_check
+ *
+ * Bounds check is enabled by default, but it may be too restrictive
+ * Pass true to enable, false to disable
+ * Returns previous state
+ */
+bool toggle_bounds_check(struct ubpf_vm *vm, bool enable);
+
+/*
  * Register an external function
  *
  * The immediate field of a CALL instruction is an index into an array of

--- a/vm/ubpf_int.h
+++ b/vm/ubpf_int.h
@@ -33,6 +33,7 @@ struct ubpf_vm {
     size_t jitted_size;
     ext_func *ext_funcs;
     const char **ext_func_names;
+    bool bounds_check_enabled;
 };
 
 char *ubpf_error(const char *fmt, ...);


### PR DESCRIPTION
bounds_check routine assumes that memory to read / write may only be on the stack or within ubpf code itself.
The toggle allows disabling the check when the assumption is not correct.