### PR TITLE
Added musl support

### DIFF
--- a/vm/test.c
+++ b/vm/test.c
@@ -192,6 +192,17 @@ static void *readfile(const char *path, size_t maxlen, size_t *len)
     return data;
 }
 
+#ifndef __GLIBC__
+void *
+memfrob(void *s, size_t n)
+{
+    for (int i = 0; i < n; i++) {
+        ((char *)s)[i] ^= 42;
+    }
+    return s;
+}
+#endif
+
 static uint64_t
 gather_bytes(uint8_t a, uint8_t b, uint8_t c, uint8_t d, uint8_t e)
 {

--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -22,6 +22,7 @@
 #include <stdarg.h>
 #include <inttypes.h>
 #include <sys/mman.h>
+#include <endian.h>
 #include "ubpf_int.h"
 
 #define MAX_EXT_FUNCS 64


### PR DESCRIPTION
`memfrob` is a glibc function, so we reimplement it if it doesn't exist. `endian.h` is required for the `htobe*` functions.