### PR TITLE
Zero-initialize registers

### DIFF
--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -139,7 +139,7 @@ ubpf_exec(const struct ubpf_vm *vm, void *mem, size_t mem_len)
 {
     uint16_t pc = 0;
     const struct ebpf_inst *insts = vm->insts;
-    uint64_t reg[16];
+    uint64_t reg[16] = {0};
     uint64_t stack[(STACK_SIZE+7)/8];
 
     if (!insts) {


### PR DESCRIPTION
This ensures that return values of simple programs are predictable, and makes debugging a whole lot easier.