### PR TITLE
ubpf.h: Add <stdbool.h> to external header file

### DIFF
--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -19,6 +19,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 
 struct ubpf_vm;
 typedef uint64_t (*ubpf_jit_fn)(void *mem, size_t mem_len);


### PR DESCRIPTION
Commit 089f627 added the bool type to an external function but did not
add the approriate header to define that type. This still allowed the
library to be built because <stdbool.h> was included in the internal
library source files. However it causes issues when linking to this
library from other programs.

Fixes #38