### PR TITLE
.travis: Fix Python3.5 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,10 @@ jobs:
         - sudo apt-get update
         - sudo apt-get -y install python3 python3-pip python3-setuptools python3-wheel
 # command to install dependencies
-install: 
-  - $PYTHON -m pip install --user -r requirements.txt
-  - $PYTHON -m pip install --user cpp-coveralls
+install:
+  - $PYTHON -m pip install --upgrade "pip<21.0"
+  - $PYTHON -m pip install -r requirements.txt
+  - $PYTHON -m pip install cpp-coveralls
 # command to run tests
 script: 
   - make -C vm COVERAGE=1


### PR DESCRIPTION
Newer versions of pip are required to install recent versions of `cpp-coveralls`. However, pip >= 21 is incompatible with Python 3.5.
