### PR TITLE
ubpf_vm: Add mem_len via R2 into uBPF VM

### DIFF
--- a/tests/mem-len.data
+++ b/tests/mem-len.data
@@ -1,0 +1,9 @@
+-- asm
+mov r0, r2
+exit
+-- mem
+00 00 00 01
+00 00 00 02
+-- no register offset
+-- result
+0x8

--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -148,6 +148,7 @@ ubpf_exec(const struct ubpf_vm *vm, void *mem, size_t mem_len)
     }
 
     reg[1] = (uintptr_t)mem;
+    reg[2] = (uint64_t)mem_len;
     reg[10] = (uintptr_t)stack + sizeof(stack);
 
     while (1) {


### PR DESCRIPTION
It is useful for programs to be able to operate based on the length of
the input data passed in to it. Pass in this length via the R2
register.

Fixes #57.