### PR TITLE
Removed ubpf_jit_x86_64.o rule in the VM Makefile.

### DIFF
--- a/vm/Makefile
+++ b/vm/Makefile
@@ -29,9 +29,7 @@ CFLAGS += -fsanitize=address
 LDFLAGS += -fsanitize=address
 endif
 
-all: libubpf.a test
-
-ubpf_jit_x86_64.o: ubpf_jit_x86_64.c ubpf_jit_x86_64.h
+all: test
 
 libubpf.a: ubpf_vm.o ubpf_jit_x86_64.o ubpf_loader.o
 	ar rc $@ $^


### PR DESCRIPTION
* `ubpf_jit_x86_64.o` is already existed in building the `libubpf.a` archive rule.
* `libubpf.a` also is required for `test`, so it can be removed from `all` rule.

Signed-off-by: Alireza Sanaee <sarsanaee@gmail.com>