### PR TITLE
Permit overriding maximum stack size

### DIFF
--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -21,6 +21,15 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+// Default values for maximum instruction count and stack size.
+#if !defined(UBPF_MAX_INSTS)
+#define UBPF_MAX_INSTS 65536
+#endif
+
+#if !defined(UBPF_STACK_SIZE)
+#define UBPF_STACK_SIZE 128
+#endif
+
 struct ubpf_vm;
 typedef uint64_t (*ubpf_jit_fn)(void *mem, size_t mem_len);
 

--- a/vm/ubpf_int.h
+++ b/vm/ubpf_int.h
@@ -20,11 +20,6 @@
 #include <ubpf.h>
 #include "ebpf.h"
 
-#define MAX_INSTS 65536
-#if !defined(STACK_SIZE)
-#define STACK_SIZE 128
-#endif
-
 struct ebpf_inst;
 typedef uint64_t (*ext_func)(uint64_t arg0, uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4);
 

--- a/vm/ubpf_int.h
+++ b/vm/ubpf_int.h
@@ -21,7 +21,9 @@
 #include "ebpf.h"
 
 #define MAX_INSTS 65536
+#if !defined(STACK_SIZE)
 #define STACK_SIZE 128
+#endif
 
 struct ebpf_inst;
 typedef uint64_t (*ext_func)(uint64_t arg0, uint64_t arg1, uint64_t arg2, uint64_t arg3, uint64_t arg4);

--- a/vm/ubpf_jit_x86_64.c
+++ b/vm/ubpf_jit_x86_64.c
@@ -139,7 +139,7 @@ translate(struct ubpf_vm *vm, struct jit_state *state, char **errmsg)
     emit_mov(state, RSP, map_register(10));
 
     /* Allocate stack space */
-    emit_alu64_imm32(state, 0x81, 5, RSP, STACK_SIZE);
+    emit_alu64_imm32(state, 0x81, 5, RSP, UBPF_STACK_SIZE);
 
     for (i = 0; i < vm->num_insts; i++) {
         struct ebpf_inst inst = vm->insts[i];
@@ -470,7 +470,7 @@ translate(struct ubpf_vm *vm, struct jit_state *state, char **errmsg)
     }
 
     /* Deallocate stack space */
-    emit_alu64_imm32(state, 0x81, 0, RSP, STACK_SIZE);
+    emit_alu64_imm32(state, 0x81, 0, RSP, UBPF_STACK_SIZE);
 
     /* Restore platform non-volatile registers */
     for (i = 0; i < _countof(platform_nonvolatile_registers); i++)
@@ -590,8 +590,8 @@ ubpf_translate(struct ubpf_vm *vm, uint8_t * buffer, size_t * size, char **errms
     state.offset = 0;
     state.size = *size;
     state.buf = buffer;
-    state.pc_locs = calloc(MAX_INSTS+1, sizeof(state.pc_locs[0]));
-    state.jumps = calloc(MAX_INSTS, sizeof(state.jumps[0]));
+    state.pc_locs = calloc(UBPF_MAX_INSTS+1, sizeof(state.pc_locs[0]));
+    state.jumps = calloc(UBPF_MAX_INSTS, sizeof(state.jumps[0]));
     state.num_jumps = 0;
 
     if (translate(vm, &state, errmsg) < 0) {

--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -149,7 +149,7 @@ ubpf_exec(const struct ubpf_vm *vm, void *mem, size_t mem_len)
     uint16_t pc = 0;
     const struct ebpf_inst *insts = vm->insts;
     uint64_t reg[16];
-    uint64_t stack[(STACK_SIZE+7)/8];
+    uint64_t stack[(UBPF_STACK_SIZE+7)/8];
 
     if (!insts) {
         /* Code must be loaded before we can execute */
@@ -574,8 +574,8 @@ ubpf_exec(const struct ubpf_vm *vm, void *mem, size_t mem_len)
 static bool
 validate(const struct ubpf_vm *vm, const struct ebpf_inst *insts, uint32_t num_insts, char **errmsg)
 {
-    if (num_insts >= MAX_INSTS) {
-        *errmsg = ubpf_error("too many instructions (max %u)", MAX_INSTS);
+    if (num_insts >= UBPF_MAX_INSTS) {
+        *errmsg = ubpf_error("too many instructions (max %u)", UBPF_MAX_INSTS);
         return false;
     }
 
@@ -756,11 +756,11 @@ bounds_check(const struct ubpf_vm *vm, void *addr, int size, const char *type, u
     if (mem && (addr >= mem && ((char*)addr + size) <= ((char*)mem + mem_len))) {
         /* Context access */
         return true;
-    } else if (addr >= stack && ((char*)addr + size) <= ((char*)stack + STACK_SIZE)) {
+    } else if (addr >= stack && ((char*)addr + size) <= ((char*)stack + UBPF_STACK_SIZE)) {
         /* Stack access */
         return true;
     } else {
-        vm->error_printf(stderr, "uBPF error: out of bounds memory %s at PC %u, addr %p, size %d\nmem %p/%zd stack %p/%d\n", type, cur_pc, addr, size, mem, mem_len, stack, STACK_SIZE);
+        vm->error_printf(stderr, "uBPF error: out of bounds memory %s at PC %u, addr %p, size %d\nmem %p/%zd stack %p/%d\n", type, cur_pc, addr, size, mem, mem_len, stack, UBPF_STACK_SIZE);
         return false;
     }
 }


### PR DESCRIPTION
Permit overriding maximum stack size at compile time.

Resolves: #65 

Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>