### PR TITLE
Fix register mapping to avoid volatile registers and issues with R12

### DIFF
--- a/vm/ubpf_jit_x86_64.c
+++ b/vm/ubpf_jit_x86_64.c
@@ -51,7 +51,7 @@ static int platform_nonvolatile_registers[] = {
 static int platform_parameter_registers[] = {
     RCX, RDX, R8, R9
 };
-#define RCX_ALT R15
+#define RCX_ALT R10
 // Register assignments:
 // BPF R0-R4 are "volatile"
 // BPF R5-R10 are "non-volatile"
@@ -64,11 +64,11 @@ static int register_map[REGISTER_MAP_SIZE] = {
     RDX,
     R8,
     R9,
-    RBX,
+    R14,
+    R15,
     RDI,
     RSI,
-    R13,
-    R14,
+    RBX,
     RBP,
 };
 #else

--- a/vm/ubpf_jit_x86_64.c
+++ b/vm/ubpf_jit_x86_64.c
@@ -60,7 +60,7 @@ static int platform_parameter_registers[] = {
 // Avoid R12 as we don't support encoding modrm modifier for using R12.
 static int register_map[REGISTER_MAP_SIZE] = {
     RAX,
-    R15,
+    R10,
     RDX,
     R8,
     R9,

--- a/vm/ubpf_jit_x86_64.c
+++ b/vm/ubpf_jit_x86_64.c
@@ -52,15 +52,21 @@ static int platform_parameter_registers[] = {
     RCX, RDX, R8, R9
 };
 #define RCX_ALT R15
+// Register assignments:
+// BPF R0-R4 are "volatile"
+// BPF R5-R10 are "non-volatile"
+// Map BPF volatile registers to x64 volatile and map BPF non-volatile to
+// x64 non-volatile.
+// Avoid R12 as we don't support encoding modrm modifier for using R12.
 static int register_map[REGISTER_MAP_SIZE] = {
     RAX,
     R15,
     RDX,
     R8,
     R9,
-    R10,
-    R11,
-    R12,
+    RBX,
+    RDI,
+    RSI,
     R13,
     R14,
     RBP,


### PR DESCRIPTION
Fix register mapping to avoid volatile registers and issues with R12

Resolves: #77 

Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>