### PR TITLE
ubpf_exec should separate errors returned from the return value

### DIFF
--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -98,7 +98,7 @@ int ubpf_load(struct ubpf_vm *vm, const void *code, uint32_t code_len, char **er
  */
 int ubpf_load_elf(struct ubpf_vm *vm, const void *elf, size_t elf_len, char **errmsg);
 
-uint64_t ubpf_exec(const struct ubpf_vm *vm, void *mem, size_t mem_len);
+int ubpf_exec(const struct ubpf_vm *vm, void *mem, size_t mem_len, uint64_t* bpf_return_value);
 
 ubpf_jit_fn ubpf_compile(struct ubpf_vm *vm, char **errmsg);
 

--- a/vm/test.c
+++ b/vm/test.c
@@ -139,7 +139,8 @@ int main(int argc, char **argv)
         }
         ret = fn(mem, mem_len);
     } else {
-        ret = ubpf_exec(vm, mem, mem_len);
+        if (ubpf_exec(vm, mem, mem_len, &ret) < 0)
+            ret = UINT64_MAX;
     }
 
     printf("0x%"PRIx64"\n", ret);


### PR DESCRIPTION
ubpf_exec should separate errors returned from the return value

Resolves: #79 

Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>