### PR TITLE
Implement unwind on success semantics to support bpf_tail_call

### DIFF
--- a/tests/call_unwind.data
+++ b/tests/call_unwind.data
@@ -1,0 +1,9 @@
+-- asm
+mov r1, 0
+call 5
+mov r0, 2
+exit
+-- result
+0x0
+-- no register offset
+call instruction

--- a/tests/call_unwind_fail.data
+++ b/tests/call_unwind_fail.data
@@ -1,0 +1,9 @@
+-- asm
+mov r1, -1
+call 5
+mov r0, 2
+exit
+-- result
+0x2
+-- no register offset
+call instruction

--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -112,4 +112,14 @@ ubpf_jit_fn ubpf_compile(struct ubpf_vm *vm, char **errmsg);
  * message will be stored in 'errmsg' and should be freed by the caller.
  */
 int ubpf_translate(struct ubpf_vm *vm, uint8_t *buffer, size_t *size, char **errmsg);
+
+/*
+ * Instruct the uBPF runtime to apply unwind-on-success semantics to a helper
+ * function. If the function returns 0, the uBPF runtime will end execution of
+ * the eBPF program and immediately return control to the caller. This is used
+ * for implementing function like the "bpf_tail_call" helper. 
+ * Returns 0 on success, -1 on if there is already an unwind helper set.
+ */
+int ubpf_set_unwind_function_index(struct ubpf_vm *vm, unsigned int idx);
+
 #endif

--- a/vm/test.c
+++ b/vm/test.c
@@ -226,6 +226,12 @@ sqrti(uint32_t x)
     return sqrt(x);
 }
 
+static uint64_t
+unwind(uint64_t i)
+{
+    return i;
+}
+
 static void
 register_functions(struct ubpf_vm *vm)
 {
@@ -234,4 +240,6 @@ register_functions(struct ubpf_vm *vm)
     ubpf_register(vm, 2, "trash_registers", trash_registers);
     ubpf_register(vm, 3, "sqrti", sqrti);
     ubpf_register(vm, 4, "strcmp_ext", strcmp);
+    ubpf_register(vm, 5, "unwind", unwind);
+    ubpf_set_unwind_function_index(vm, 5);
 }

--- a/vm/ubpf_int.h
+++ b/vm/ubpf_int.h
@@ -32,6 +32,7 @@ struct ubpf_vm {
     const char **ext_func_names;
     bool bounds_check_enabled;
     int (*error_printf)(FILE* stream, const char* format, ...);
+    int unwind_stack_extension_index;
 };
 
 char *ubpf_error(const char *fmt, ...);

--- a/vm/ubpf_jit_x86_64.c
+++ b/vm/ubpf_jit_x86_64.c
@@ -408,6 +408,10 @@ translate(struct ubpf_vm *vm, struct jit_state *state, char **errmsg)
             /* We reserve RCX for shifts */
             emit_mov(state, RCX_ALT, RCX);
             emit_call(state, vm->ext_funcs[inst.imm]);
+            if (inst.imm == vm->unwind_stack_extension_index) {
+                emit_cmp_imm32(state, map_register(0), 0);
+                emit_jcc(state, 0x84, TARGET_PC_EXIT);
+            }
             break;
         case EBPF_OP_EXIT:
             if (i != vm->num_insts - 1) {

--- a/vm/ubpf_jit_x86_64.h
+++ b/vm/ubpf_jit_x86_64.h
@@ -61,6 +61,7 @@ struct jit_state {
     uint32_t *pc_locs;
     uint32_t exit_loc;
     uint32_t div_by_zero_loc;
+    uint32_t unwind_loc;
     struct jump *jumps;
     int num_jumps;
 };


### PR DESCRIPTION
bpf_tail_call has special semantics.

If the call returns success, then ubpf needs to store the return value and unwind the stack so to the caller.

Signed-off-by: Alan Jowett <Alan.Jowett@microsoft.com>