### PR TITLE
Add option to enable eBPF hardening mitigations.

### DIFF
--- a/test_framework/test_jit.py
+++ b/test_framework/test_jit.py
@@ -12,7 +12,7 @@ try:
 except NameError:
     xrange = range
 
-def check_datafile(filename):
+def check_datafile(filename, mode):
     """
     Given assembly source code and an expected result, run the eBPF program and
     verify that the result matches. Uses the JIT compiler.
@@ -53,6 +53,8 @@ def check_datafile(filename):
                 cmd.extend(['-R'])
             if 'unload' in data:
                 cmd.extend(['-U'])
+            if 'MITIGATIONS' in mode:
+                cmd.extend(['-d'])
             cmd.extend(['-j', '-r', str(register_offset), '-'])
 
             vm = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
@@ -90,4 +92,5 @@ def test_datafiles():
     # Nose test generator
     # Creates a testcase for each datafile
     for filename in testdata.list_files():
-        yield check_datafile, filename
+        yield check_datafile, filename, 'JIT'
+        yield check_datafile, filename, 'JIT_WITH_MITIGATIONS'

--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -134,4 +134,14 @@ int ubpf_translate(struct ubpf_vm *vm, uint8_t *buffer, size_t *size, char **err
  */
 int ubpf_set_unwind_function_index(struct ubpf_vm *vm, unsigned int idx);
 
+/* 
+ * Enable mitigations for code from a less trusted source. Note: Mitigations may
+ * degrade performance.
+ * 
+ * Mitigations currently include:
+ *   Constant blinding - All constants in the code are blinded to prevent JIT 
+ *   spraying attacks.
+ */
+void ubpf_enable_mitigations(struct ubpf_vm *vm);
+
 #endif

--- a/vm/ubpf_int.h
+++ b/vm/ubpf_int.h
@@ -31,6 +31,7 @@ struct ubpf_vm {
     ext_func *ext_funcs;
     const char **ext_func_names;
     bool bounds_check_enabled;
+    bool constant_blinding_enabled;
     int (*error_printf)(FILE* stream, const char* format, ...);
     int unwind_stack_extension_index;
 };

--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -44,6 +44,11 @@ void ubpf_set_error_print(struct ubpf_vm *vm, int (*error_printf)(FILE* stream, 
         vm->error_printf = fprintf;
 }
 
+void ubpf_enable_mitigations(struct ubpf_vm *vm)
+{
+    vm->constant_blinding_enabled = true;
+}
+
 struct ubpf_vm *
 ubpf_create(void)
 {
@@ -66,8 +71,8 @@ ubpf_create(void)
 
     vm->bounds_check_enabled = true;
     vm->error_printf = fprintf;
-
     vm->unwind_stack_extension_index = -1;
+    vm->constant_blinding_enabled = false;
     return vm;
 }
 


### PR DESCRIPTION
First draft includes constant blinding for ALU operations on 32-bit immediate values.

https://ebpf.io/what-is-ebpf/#:~:text=Hardening

Signed-off-by: Alan Jowett <Alan.Jowett@microsoft.com>