### PR TITLE
vm/inc: include stdio.h

### DIFF
--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -17,6 +17,7 @@
 #ifndef UBPF_H
 #define UBPF_H
 
+#include <stdio.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>


### PR DESCRIPTION
The introduction of ubpf_set_error_print() breaks using ubpf as an
external library.

For example, the simple program:

    #include <ubpf.h>

    int main()
    {
        return 0;
    }

Fails to compile with the following (gcc 8.4.0, Ubuntu 18.04):

    In file included from a.c:1:
    /usr/local/include/ubpf.h:54:67: error: unknown type name ‘FILE’
     void ubpf_set_error_print(struct ubpf_vm *vm, int (*error_printf)(FILE* stream, const char* format, ...));
                                                                       ^~~~
    /usr/local/include/ubpf.h:54:67: note: ‘FILE’ is defined in header ‘<stdio.h>’; did you forget to ‘#include <stdio.h>’?
    /usr/local/include/ubpf.h:23:1:
    +#include <stdio.h>

    /usr/local/include/ubpf.h:54:67:
     void ubpf_set_error_print(struct ubpf_vm *vm, int (*error_printf)(FILE* stream, const char* format, ...));

To fix it, simply include stdio.h.

Fixes: d2c7bdc2bfc4 ("Minimal set of changes required for ubpf to work on Windows.")