### PR TITLE
Add debug callout to ubpf VM interpreter mode

### DIFF
--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -134,6 +134,12 @@ int ubpf_translate(struct ubpf_vm *vm, uint8_t *buffer, size_t *size, char **err
  */
 int ubpf_set_unwind_function_index(struct ubpf_vm *vm, unsigned int idx);
 
+/*
+ * Add a debug callout that is invoked prior to each eBPF instruction being
+ * executed. Debug callout has access to the complete VM state and can be
+ * leveraged to debug the program.
+ * Returns 0 on success, -1 on if there is already a debug callout set.
+ */
 int ubpf_set_debug_callout(struct ubpf_vm *vm, void (*debug)(uint16_t program_counter, uint64_t instruction, uint64_t registers[11], uint64_t stack[(UBPF_STACK_SIZE+7)/8]));
 
 #endif

--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -140,6 +140,6 @@ int ubpf_set_unwind_function_index(struct ubpf_vm *vm, unsigned int idx);
  * leveraged to debug the program.
  * Returns 0 on success, -1 on if there is already a debug callout set.
  */
-int ubpf_set_debug_callout(struct ubpf_vm *vm, void (*debug)(uint16_t program_counter, uint64_t instruction, uint64_t registers[11], uint64_t stack[(UBPF_STACK_SIZE+7)/8]));
+int ubpf_set_debug_callout(struct ubpf_vm *vm, void* context, void (*debug)(void* context, uint16_t program_counter, uint64_t instruction, uint64_t registers[11], uint64_t stack[(UBPF_STACK_SIZE+7)/8]));
 
 #endif

--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -134,4 +134,6 @@ int ubpf_translate(struct ubpf_vm *vm, uint8_t *buffer, size_t *size, char **err
  */
 int ubpf_set_unwind_function_index(struct ubpf_vm *vm, unsigned int idx);
 
+int ubpf_set_debug_callout(struct ubpf_vm *vm, void (*debug)(uint16_t program_counter, uint64_t instruction, uint64_t registers[11], uint64_t stack[(UBPF_STACK_SIZE+7)/8]));
+
 #endif

--- a/vm/ubpf_int.h
+++ b/vm/ubpf_int.h
@@ -33,7 +33,8 @@ struct ubpf_vm {
     bool bounds_check_enabled;
     int (*error_printf)(FILE* stream, const char* format, ...);
     int unwind_stack_extension_index;
-    void (*debug_callout)(uint16_t program_counter, uint64_t instruction, uint64_t registers[11], uint64_t stack[(UBPF_STACK_SIZE+7)/8]);
+    void *debug_context;
+    void (*debug_callout)(void *debug_context, uint16_t program_counter, uint64_t instruction, uint64_t registers[11], uint64_t stack[(UBPF_STACK_SIZE+7)/8]);
 };
 
 char *ubpf_error(const char *fmt, ...);

--- a/vm/ubpf_int.h
+++ b/vm/ubpf_int.h
@@ -33,6 +33,7 @@ struct ubpf_vm {
     bool bounds_check_enabled;
     int (*error_printf)(FILE* stream, const char* format, ...);
     int unwind_stack_extension_index;
+    void (*debug_callout)(uint16_t program_counter, uint64_t instruction, uint64_t registers[11], uint64_t stack[(UBPF_STACK_SIZE+7)/8]);
 };
 
 char *ubpf_error(const char *fmt, ...);

--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -162,6 +162,15 @@ ubpf_unload_code(struct ubpf_vm *vm)
     }
 }
 
+int ubpf_set_debug_callout(struct ubpf_vm *vm, void (*debug)(uint16_t program_counter, uint64_t instruction, uint64_t registers[11], uint64_t stack[(UBPF_STACK_SIZE+7)/8]))
+{
+    if (vm->debug_callout) {
+        return -1;
+    }
+    vm->debug_callout = debug;
+    return 0;
+}
+
 static uint32_t
 u32(uint64_t x)
 {
@@ -187,7 +196,11 @@ ubpf_exec(const struct ubpf_vm *vm, void *mem, size_t mem_len, uint64_t* bpf_ret
 
     while (1) {
         const uint16_t cur_pc = pc;
+
         struct ebpf_inst inst = insts[pc++];
+        if (vm->debug_callout) {
+            vm->debug_callout(pc-1, *(uint64_t*)&inst, reg, stack);
+        }
 
         switch (inst.opcode) {
         case EBPF_OP_ADD_IMM:


### PR DESCRIPTION
It would be useful to have the ability to single-step through an eBPF program. The best way to achieve this is to add a debug hook to the VM that is invoked prior to each instruction. 

Resolves: #93 

Signed-off-by: Alan Jowett <alanjo@microsoft.com>