### PR TITLE
Enable ubpf on platforms with no supported JIT

### DIFF
--- a/test_framework/test_elf.py
+++ b/test_framework/test_elf.py
@@ -117,14 +117,14 @@ exit
         st_value=0,
         st_size=0,
         st_info=Container(bind='STB_WEAK', type='STT_FUNC'),
-        st_other=Container(visibility='STV_DEFAULT'),
+        st_other=Container(local=0, visibility='STV_DEFAULT'),
         st_shndx=0))
     add("sqrti_sym", Container(
         st_name=28,
         st_value=0,
         st_size=0,
         st_info=Container(bind='STB_WEAK', type='STT_FUNC'),
-        st_other=Container(visibility='STV_DEFAULT'),
+        st_other=Container(local=0, visibility='STV_DEFAULT'),
         st_shndx=0))
     add("sqrti_rel", Container(
         r_info=(1 << 32) | 2,

--- a/test_framework/test_jit.py
+++ b/test_framework/test_jit.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import tempfile
 import struct
 import re
@@ -12,11 +13,18 @@ try:
 except NameError:
     xrange = range
 
+def jit_supported_platform():
+    """Is the JIT supported on the current platform."""
+    return platform.machine() in ['amd64', 'x86_64']
+    
 def check_datafile(filename):
     """
     Given assembly source code and an expected result, run the eBPF program and
     verify that the result matches. Uses the JIT compiler.
     """
+    if not jit_supported_platform():
+        raise SkipTest("JIT is not supported on the current platform")
+
     data = testdata.read(filename)
     if 'asm' not in data and 'raw' not in data:
         raise SkipTest("no asm or raw section in datafile")

--- a/vm/Makefile
+++ b/vm/Makefile
@@ -33,7 +33,7 @@ all: libubpf.a test
 
 ubpf_jit_x86_64.o: ubpf_jit_x86_64.c ubpf_jit_x86_64.h
 
-libubpf.a: ubpf_vm.o ubpf_jit_x86_64.o ubpf_loader.o
+libubpf.a: ubpf_vm.o ubpf_jit_x86_64.o ubpf_loader.o ubpf_jit.o
 	ar rc $@ $^
 
 test: test.o libubpf.a

--- a/vm/test.c
+++ b/vm/test.c
@@ -233,6 +233,7 @@ gather_bytes(uint8_t a, uint8_t b, uint8_t c, uint8_t d, uint8_t e)
 static void
 trash_registers(void)
 {
+#if __x86_64__
     /* Overwrite all caller-save registers */
     asm(
         "mov $0xf0, %rax;"
@@ -245,6 +246,10 @@ trash_registers(void)
         "mov $0xf7, %r10;"
         "mov $0xf8, %r11;"
     );
+#else
+    fprintf(stderr, "trash_registers not implemented for this architecture.\n");
+    exit(1);
+#endif
 }
 
 static uint32_t

--- a/vm/ubpf_int.h
+++ b/vm/ubpf_int.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2015 Big Switch Networks, Inc
+ * Copyright 2022 Linaro Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +33,13 @@ struct ubpf_vm {
     const char **ext_func_names;
     bool bounds_check_enabled;
     int (*error_printf)(FILE* stream, const char* format, ...);
+    int (*translate)(struct ubpf_vm *vm, uint8_t *buffer, size_t *size, char **errmsg);
     int unwind_stack_extension_index;
 };
+
+/* The various JIT targets.  */
+int ubpf_translate_x86_64(struct ubpf_vm *vm, uint8_t * buffer, size_t * size, char **errmsg);
+int ubpf_translate_null(struct ubpf_vm *vm, uint8_t * buffer, size_t * size, char **errmsg);
 
 char *ubpf_error(const char *fmt, ...);
 unsigned int ubpf_lookup_registered_function(struct ubpf_vm *vm, const char *name);

--- a/vm/ubpf_jit.c
+++ b/vm/ubpf_jit.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2015 Big Switch Networks, Inc
+ * Copyright 2017 Google Inc.
+ * Copyright 2022 Linaro Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <inttypes.h>
+#include <sys/mman.h>
+#include <errno.h>
+#include <assert.h>
+#include "ubpf_int.h"
+#include "ubpf_jit_x86_64.h"
+
+#define UNUSED(x) ((void)x)
+
+int
+ubpf_translate(struct ubpf_vm *vm, uint8_t *buffer, size_t *size, char **errmsg)
+{
+    return vm->translate(vm, buffer, size, errmsg);
+}
+
+int
+ubpf_translate_null(struct ubpf_vm *vm, uint8_t * buffer, size_t * size, char **errmsg)
+{
+    /* NULL JIT target - just returns an error. */
+    UNUSED(vm);
+    UNUSED(buffer);
+    UNUSED(size);
+    *errmsg = ubpf_error("Code can not be JITed on this target.");
+    return -1;
+}
+
+ubpf_jit_fn
+ubpf_compile(struct ubpf_vm *vm, char **errmsg)
+{
+    void *jitted = NULL;
+    uint8_t *buffer = NULL;
+    size_t jitted_size;
+
+    if (vm->jitted) {
+        return vm->jitted;
+    }
+
+    *errmsg = NULL;
+
+    if (!vm->insts) {
+        *errmsg = ubpf_error("code has not been loaded into this VM");
+        return NULL;
+    }
+
+    jitted_size = 65536;
+    buffer = calloc(jitted_size, 1);
+
+    if (ubpf_translate(vm, buffer, &jitted_size, errmsg) < 0) {
+        goto out;
+    }
+
+    jitted = mmap(0, jitted_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (jitted == MAP_FAILED) {
+        *errmsg = ubpf_error("internal uBPF error: mmap failed: %s\n", strerror(errno));
+        goto out;
+    }
+
+    memcpy(jitted, buffer, jitted_size);
+
+    if (mprotect(jitted, jitted_size, PROT_READ | PROT_EXEC) < 0) {
+        *errmsg = ubpf_error("internal uBPF error: mprotect failed: %s\n", strerror(errno));
+        goto out;
+    }
+
+    vm->jitted = jitted;
+    vm->jitted_size = jitted_size;
+
+out:
+    free(buffer);
+    if (jitted && vm->jitted == NULL) {
+        munmap(jitted, jitted_size);
+    }
+    return vm->jitted;
+}

--- a/vm/ubpf_jit_x86_64.c
+++ b/vm/ubpf_jit_x86_64.c
@@ -626,7 +626,7 @@ resolve_strings(struct jit_state *state)
 
 
 int
-ubpf_translate(struct ubpf_vm *vm, uint8_t * buffer, size_t * size, char **errmsg)
+ubpf_translate_x86_64(struct ubpf_vm *vm, uint8_t * buffer, size_t * size, char **errmsg)
 {
     struct jit_state state;
     int result = -1;
@@ -670,53 +670,4 @@ out:
     free(state.jumps);
     free(state.strings);
     return result;
-}
-
-ubpf_jit_fn
-ubpf_compile(struct ubpf_vm *vm, char **errmsg)
-{
-    void *jitted = NULL;
-    uint8_t *buffer = NULL;
-    size_t jitted_size;
-
-    if (vm->jitted) {
-        return vm->jitted;
-    }
-
-    *errmsg = NULL;
-
-    if (!vm->insts) {
-        *errmsg = ubpf_error("code has not been loaded into this VM");
-        return NULL;
-    }
-
-    jitted_size = 65536;
-    buffer = calloc(jitted_size, 1);
-
-    if (ubpf_translate(vm, buffer, &jitted_size, errmsg) < 0) {
-        goto out;
-    }
-
-    jitted = mmap(0, jitted_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    if (jitted == MAP_FAILED) {
-        *errmsg = ubpf_error("internal uBPF error: mmap failed: %s\n", strerror(errno));
-        goto out;
-    }
-
-    memcpy(jitted, buffer, jitted_size);
-
-    if (mprotect(jitted, jitted_size, PROT_READ | PROT_EXEC) < 0) {
-        *errmsg = ubpf_error("internal uBPF error: mprotect failed: %s\n", strerror(errno));
-        goto out;
-    }
-
-    vm->jitted = jitted;
-    vm->jitted_size = jitted_size;
-
-out:
-    free(buffer);
-    if (jitted && vm->jitted == NULL) {
-        munmap(jitted, jitted_size);
-    }
-    return vm->jitted;
 }

--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -71,6 +71,11 @@ ubpf_create(void)
     vm->bounds_check_enabled = true;
     vm->error_printf = fprintf;
 
+#if __x86_64__
+    vm->translate = ubpf_translate_x86_64;
+#else
+    vm->translate = ubpf_translate_null;
+#endif
     vm->unwind_stack_extension_index = -1;
     return vm;
 }


### PR DESCRIPTION
As a first step in adding an Arm64 JIT to ubpf this PR enables building the library on platforms with no JIT target implemented.  It also updates the testsuite to skip trying to run the JIT tests on those platforms.  It does this by adding a 'null' JIT that always fails.

The approach taken for the build system is to assume that all JITs (currently just x86_64 and null) will successfully build on all platforms, but that only the JIT required for the target platform will be used.

Building and testing on Arm64 platforms highlighted an issue with elftools which is worked around in the second commit.

This has been tested successfully on x86_64 and Arm64 platforms.