### PR TITLE
Fix Address Sanitizer failures

### DIFF
--- a/vm/test.c
+++ b/vm/test.c
@@ -162,6 +162,7 @@ load:
         if (fn == NULL) {
             fprintf(stderr, "Failed to compile: %s\n", errmsg);
             free(errmsg);
+            free(mem);
             return 1;
         }
         ret = fn(mem, mem_len);
@@ -173,6 +174,7 @@ load:
     printf("0x%"PRIx64"\n", ret);
 
     ubpf_destroy(vm);
+    free(mem);
 
     return 0;
 }


### PR DESCRIPTION
Building and running with Address Sanitizer enabled leads to failures on x86-64:

```
make -C vm ASAN=1
nosetests
```

These are all due to the test harness not freeing the memory allocated to hold the contents of the "-- mem" data.  Adding appropriate calls to `free()` fixes these issues.

Tested on x86-64.