### PR TITLE
Pin to version 0.27 of pyelf until issues are resolved

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # pypi version of parcon does not support python3
 git+https://github.com/javawizard/parcon
 nose ~= 1.3.1
-pyelftools ~= 0.27
+pyelftools == 0.27


### PR DESCRIPTION
pyelf version 0.28 fails during CI/CD.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>