### PR TITLE
vm: include ubpf_jit.o in dynamic library

### DIFF
--- a/vm/Makefile
+++ b/vm/Makefile
@@ -40,7 +40,7 @@ ubpf_jit_x86_64.o: ubpf_jit_x86_64.c ubpf_jit_x86_64.h
 libubpf.a: ubpf_vm.o ubpf_jit_arm64.o ubpf_jit_x86_64.o ubpf_loader.o ubpf_jit.o
 	ar rc $@ $^
 
-libubpf.so: ubpf_vm.o ubpf_jit_x86_64.o ubpf_loader.o
+libubpf.so: ubpf_vm.o ubpf_jit_arm64.o ubpf_jit_x86_64.o ubpf_loader.o ubpf_jit.o
 	$(CC) -shared -o $@ $^ $(LDLIBS)
 
 test: test.o libubpf.a


### PR DESCRIPTION
When #97 and #48 were merged at the same time, certain symbols are included in `libubpf.a` but not in `libubpf.so`.
That causes linker errors such as:

```text
libndn-dpdk-c.a.p/csrc_strategycode_load.c.o: In function `StrategyCode_LoadUbpf':
build/../csrc/strategycode/load.c:40: undefined reference to `ubpf_compile'
```

This PR makes both static library and dynamic library include the same object files.