### PR TITLE
Fix CMake to permit building without test libraries

### DIFF
--- a/vm/CMakeLists.txt
+++ b/vm/CMakeLists.txt
@@ -86,9 +86,12 @@ if(TARGET "ubpf_compat")
     $<BUILD_INTERFACE:ubpf_compat>
   )
 
-  target_link_libraries("ubpf_test" PRIVATE
-    $<BUILD_INTERFACE:ubpf_compat>
-  )
+  if(UBPF_ENABLE_TESTS)
+    target_link_libraries("ubpf_test" PRIVATE
+      $<BUILD_INTERFACE:ubpf_compat>
+    )
+  endif()
+
 endif()
 
 


### PR DESCRIPTION
Resolves: #110

Only add target_link_libraries for test code if UBPF_ENABLE_TESTS is set.

Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>