### PR TITLE
Add arm64 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,28 @@ os: linux
 dist: xenial
 jobs:
   include:
-    - name: python 2.7
+    - name: python 2.7-amd64
       env: PYTHON=python2
+      arch: amd64
       before_install:
         - sudo apt-get update
         - sudo apt-get -y install python python-pip python-setuptools python-wheel
       after_success:
         - coveralls --gcov-options '\-lp' -i $PWD/vm/ubpf_vm.c -i $PWD/vm/ubpf_jit_x86_64.c -i $PWD/vm/ubpf_loader.c
+    - name: python-2.7-arm64
+      env: PYTHON=python2
+      arch: arm64
+      before_install:
+        - sudo apt-get update
+        - sudo apt-get -y install python python-dev python-pip python-setuptools python-wheel libffi-dev libssl-dev
+      install:
+        - $PYTHON -m pip install --upgrade "pip<21.0"
+        - $PYTHON -m pip install -r requirements.txt
+        - $PYTHON -m pip install "cryptography<3.3"
+        - $PYTHON -m pip install "pyopenssl<21.0.0"
+        - $PYTHON -m pip install cpp-coveralls
+      after_success:
+        - coveralls --gcov-options '\-lp' -i $PWD/vm/ubpf_vm.c -i $PWD/vm/ubpf_jit_arm64.c -i $PWD/vm/ubpf_loader.c
     - name: python 3.5
       env: PYTHON=python3
       before_install:


### PR DESCRIPTION
This was tested using Travis CI.

arm64 has a few different steps to satisfy the dependencies on Xenial, but other than that, it should be straightforward.