### PR TITLE
Enable unit_tests as part of CI/CD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,3 +23,7 @@ add_subdirectory("vm")
 if(UBPF_ENABLE_PACKAGE)
   include("cmake/packaging.cmake")
 endif()
+
+enable_testing()
+add_test(NAME unit_tests
+        COMMAND nosetests -v --where=${CMAKE_SOURCE_DIR})


### PR DESCRIPTION
Enable nostests as part of CI/CD

Signed-off-by: Alan Jowett <alanjo@microsoft.com>