### PR TITLE
Fix potential integer overflow loading ELF files

### DIFF
--- a/vm/ubpf_loader.c
+++ b/vm/ubpf_loader.c
@@ -113,8 +113,10 @@ ubpf_load_elf(struct ubpf_vm *vm, const void *elf, size_t elf_size, char **errms
 
     /* Parse section headers into an array */
     struct section sections[MAX_SECTIONS];
+    uint64_t shoff = ehdr->e_shoff;
     for (i = 0; i < ehdr->e_shnum; i++) {
-        const Elf64_Shdr *shdr = bounds_check(&b, ehdr->e_shoff + i*ehdr->e_shentsize, sizeof(*shdr));
+        const Elf64_Shdr *shdr = bounds_check(&b, shoff, sizeof(*shdr));
+        shoff += ehdr->e_shentsize;
         if (!shdr) {
             *errmsg = ubpf_error("bad section header offset or size");
             goto error;


### PR DESCRIPTION
When loading ELF files we calculate the location of a section header in a way that can overflow a `uint32_t` value producing a wrong result.

This commit fixes the issue by using the fact that section headers are contiguous in the ELF file.

Resolves #147 