### PR TITLE
Encode BPF instructions to mitigate ROP attacks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "inttypes.h": "c"
+    }
+}

--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -142,4 +142,11 @@ int ubpf_set_unwind_function_index(struct ubpf_vm *vm, unsigned int idx);
 void ubpf_set_registers(struct ubpf_vm *vm, uint64_t *regs);
 uint64_t *ubpf_get_registers(const struct ubpf_vm *vm);
 
+/**
+ * @brief Optional secret to improve ROP protection.
+ * 
+ * @param[in] secret Optional secret to improve ROP protection.
+ */
+void ubpf_set_pointer_secret(uint64_t secret);
+
 #endif

--- a/vm/test.c
+++ b/vm/test.c
@@ -66,6 +66,9 @@ int main(int argc, char **argv)
     bool unload = false;
     bool reload = false;
 
+    uint64_t secret = (uint64_t)rand() << 32 | (uint64_t)rand();
+    ubpf_set_pointer_secret(secret);
+
     int opt;
     while ((opt = getopt_long(argc, argv, "hm:jr:UR", longopts, NULL)) != -1) {
         switch (opt) {

--- a/vm/ubpf_int.h
+++ b/vm/ubpf_int.h
@@ -48,6 +48,25 @@ int ubpf_translate_null(struct ubpf_vm *vm, uint8_t * buffer, size_t * size, cha
 char *ubpf_error(const char *fmt, ...);
 unsigned int ubpf_lookup_registered_function(struct ubpf_vm *vm, const char *name);
 
+/**
+ * @brief Fetch the instruction at the given index.
+ * 
+ * @param[in] vm The VM to fetch the instruction from.
+ * @param[in] pc The index of the instruction to fetch.
+ * @return The instruction.
+ */
+struct ebpf_inst ubpf_fetch_instruction(const struct ubpf_vm *vm, uint16_t pc);
+
+/**
+ * @brief Store the given instruction at the given index.
+ * 
+ * @param[in] vm The VM to store the instruction in.
+ * @param[in] pc The index of the instruction to store.
+ * @param[in] inst The instruction to store.
+ */
+void ubpf_store_instruction(const struct ubpf_vm *vm, uint16_t pc, struct ebpf_inst inst);
+
+
 extern const char* ubpf_string_table[1];
 #define UBPF_STRING_ID_DIVIDE_BY_ZERO 0
 

--- a/vm/ubpf_jit_arm64.c
+++ b/vm/ubpf_jit_arm64.c
@@ -781,7 +781,7 @@ translate(struct ubpf_vm *vm, struct jit_state *state, char **errmsg)
     emit_function_prologue(state, UBPF_STACK_SIZE);
 
     for (i = 0; i < vm->num_insts; i++) {
-        struct ebpf_inst inst = vm->insts[i];
+        struct ebpf_inst inst = ubpf_fetch_instruction(vm, i);
         state->pc_locs[i] = state->offset;
 
         enum Registers dst = map_register(inst.dst);
@@ -943,7 +943,7 @@ translate(struct ubpf_vm *vm, struct jit_state *state, char **errmsg)
             break;
 
         case EBPF_OP_LDDW: {
-            struct ebpf_inst inst2 = vm->insts[++i];
+            struct ebpf_inst inst2 = ubpf_fetch_instruction(vm, ++i);
             uint64_t imm = (uint32_t)inst.imm | ((uint64_t)inst2.imm << 32);
             emit_movewide_immediate(state, true, dst, imm);
             break;

--- a/vm/ubpf_jit_x86_64.c
+++ b/vm/ubpf_jit_x86_64.c
@@ -148,7 +148,7 @@ translate(struct ubpf_vm *vm, struct jit_state *state, char **errmsg)
     emit_alu64_imm32(state, 0x81, 5, RSP, UBPF_STACK_SIZE);
 
     for (i = 0; i < vm->num_insts; i++) {
-        struct ebpf_inst inst = vm->insts[i];
+        struct ebpf_inst inst = ubpf_fetch_instruction(vm, i);
         state->pc_locs[i] = state->offset;
 
         int dst = map_register(inst.dst);
@@ -459,7 +459,7 @@ translate(struct ubpf_vm *vm, struct jit_state *state, char **errmsg)
             break;
 
         case EBPF_OP_LDDW: {
-            struct ebpf_inst inst2 = vm->insts[++i];
+            struct ebpf_inst inst2 = ubpf_fetch_instruction(vm, ++i);
             uint64_t imm = (uint32_t)inst.imm | ((uint64_t)inst2.imm << 32);
             emit_load_imm(state, dst, imm);
             break;


### PR DESCRIPTION
Add a layer of abstraction to load and store instructions in the VM.
When storing instructions, xor the instructions with the base address of the VM and optionally a user-supplied key.
When loading instructions, xor the instructions with the base address of the VM and optionally a user-supplied key.

Resolves: #81 

Signed-off-by: Alan Jowett <alanjo@microsoft.com>