### PR TITLE
Add support for custom data relocation 

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -1,3 +1,5 @@
+# Copyright (c) 2022-present, IO Visor Project
+# SPDX-License-Identifier: Apache-2.0
 #
 # Copyright (c) 2022-present, IO Visor Project
 # SPDX-License-Identifier: Apache-2.0
@@ -216,6 +218,19 @@ jobs:
 
         ${BPF_CONFORMANCE_RUNNER} ${BPF_CONFORMANCE_TEST_DIR} ${BPF_CONFORMANCE_TEST_FILTER} ${BPF_CONFORMANCE_PLUGIN_JIT}
         ${BPF_CONFORMANCE_RUNNER} ${BPF_CONFORMANCE_TEST_DIR} ${BPF_CONFORMANCE_TEST_FILTER} ${BPF_CONFORMANCE_PLUGIN_INTERPRET}
+
+    - name: Run the CTest suite
+      if: inputs.arch != 'arm64'
+      run: |
+        export CCACHE_DIR="$(pwd)/ccache"
+
+        if [[ "${{ inputs.scan_build }}" == "true" ]] ; then
+          command_prefix="scan-build -o scan_build_report"
+        fi
+
+        ${command_prefix} cmake \
+          --build build \
+          --target test
 
     - name: Generate code coverage report
       if: inputs.enable_coverage == true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ if(UBPF_ENABLE_TESTS)
   if (NOT UBPF_SKIP_EXTERNAL)
     add_subdirectory("external")
   endif()
+  add_subdirectory("bpf")
 endif()
 
 if(UBPF_ENABLE_PACKAGE)

--- a/bpf/CMakeLists.txt
+++ b/bpf/CMakeLists.txt
@@ -1,0 +1,51 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+find_program(clang_path "clang" REQUIRED)
+
+execute_process(
+  COMMAND echo "int main() { return 0;}"
+  COMMAND ${clang_path} --target=bpf -x c - -c -o /dev/null
+  ERROR_QUIET OUTPUT_QUIET
+  RESULT_VARIABLE CLANG_RETURN_CODE
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if (CLANG_RETURN_CODE EQUAL 0)
+    message(STATUS "Clang supports BPF target")
+    set(CLANG_SUPPORTS_BPF TRUE)
+else()
+    message(WARNING "Clang does not support BPF target, skipping BPF tests")
+    set(CLANG_SUPPORTS_BPF FALSE)
+endif()
+
+function(build_bpf file_name)
+    message(STATUS "Building BPF ${file_name}")
+
+    set(bpf_file_name ${file_name}.bpf.c)
+    set(bpf_file_path ${CMAKE_CURRENT_SOURCE_DIR}/${bpf_file_name})
+    set(bpf_obj_file_name ${file_name}.bpf.o)
+    set(bpf_obj_file_path ${CMAKE_CURRENT_BINARY_DIR}/${bpf_obj_file_name})
+
+    if (NOT EXISTS ${bpf_file_path})
+        message(FATAL_ERROR "BPF file ${bpf_file_path} does not exist")
+    endif()
+
+    add_custom_command(
+        OUTPUT ${bpf_obj_file_path}
+        COMMAND ${clang_path} -g -O2 -target bpf -c ${bpf_file_path} -o ${bpf_obj_file_path}
+        DEPENDS ${bpf_file_path}
+        COMMENT "Building BPF object ${bpf_obj_file_path}"
+    )
+
+    add_custom_target(${file_name}_ELF ALL DEPENDS ${bpf_obj_file_path} SOURCES ${bpf_file_path})
+
+    add_test(NAME ${file_name}_TEST_INTERPRET COMMAND "${CMAKE_BINARY_DIR}/bin/ubpf_test" "${bpf_obj_file_path}")
+    set_tests_properties(${file_name}_TEST_INTERPRET PROPERTIES PASS_REGULAR_EXPRESSION "0x0")
+    add_test(NAME ${file_name}_TEST_JIT COMMAND "${CMAKE_BINARY_DIR}/bin/ubpf_test" "${bpf_obj_file_path}")
+    set_tests_properties(${file_name}_TEST_JIT PROPERTIES PASS_REGULAR_EXPRESSION "0x0")
+endfunction()
+
+if (CLANG_SUPPORTS_BPF)
+    build_bpf(map)
+endif()

--- a/bpf/bpf.h
+++ b/bpf/bpf.h
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <stddef.h>
+
+struct bpf_map;
+
+static void* (*bpf_map_lookup_elem)(void* map, const void* key) = (void* (*)(void* map, const void* key))6;
+static int (*bpf_map_update_elem)(void* map, const void* key, const void* value, unsigned long flags) =
+    (int (*)(void*, const void*, const void*, unsigned long))7;
+static int (*bpf_map_delete_elem)(void* map, const void* key) = (int (*)(void*, const void*))8;
+
+#define BPF_MAP_TYPE_ARRAY 2
+
+struct bpf_map_def
+{
+    unsigned int type;
+    unsigned int key_size;
+    unsigned int value_size;
+    unsigned int max_entries;
+    unsigned int map_flags;
+    unsigned int inner_map_idx;
+    unsigned int numa_node;
+};

--- a/bpf/map.bpf.c
+++ b/bpf/map.bpf.c
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "bpf.h"
+
+struct bpf_map_def map = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(unsigned int),
+    .value_size = sizeof(unsigned long),
+    .max_entries = 10,
+};
+
+unsigned long
+map_test(void* memory, size_t memory_length)
+{
+    unsigned int key = 5;
+    unsigned long new_value = 0x1234567890ABCDEF;
+    unsigned long* value = bpf_map_lookup_elem(&map, &key);
+    if (value == NULL) {
+        return 1;
+    }
+
+    if (*value != 0) {
+        return 2;
+    }
+
+    if (bpf_map_update_elem(&map, &key, &new_value, 0) != 0) {
+        return 3;
+    }
+
+    value = bpf_map_lookup_elem(&map, &key);
+    if (value == NULL) {
+        return 4;
+    }
+
+    if (*value != new_value) {
+        return 5;
+    }
+
+    return 0;
+}

--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2015 Big Switch Networks, Inc
+// SPDX-License-Identifier: Apache-2.0
+
 /*
  * Copyright 2015 Big Switch Networks, Inc
  *
@@ -263,6 +266,33 @@ ubpf_get_registers(const struct ubpf_vm* vm);
  */
 int
 ubpf_set_pointer_secret(struct ubpf_vm* vm, uint64_t secret);
+
+typedef uint64_t (*ubpf_data_relocation)(
+    void* user_context, const uint8_t* data, uint64_t data_size, const char* symbol_name);
+
+/**
+ * @brief Set a relocation function for the VM.
+ *
+ * @param[in] vm The VM to set the relocation function for.
+ * @param[in] relocation The relocation function.
+ * @return int The value to insert into the BPF program.
+ */
+int
+ubpf_register_data_relocation(struct ubpf_vm* vm, void* user_context, ubpf_data_relocation relocation);
+
+typedef bool (*ubpf_bounds_check)(void* context, uint64_t addr, uint64_t size);
+
+/**
+ * @brief Set a bounds check function for the VM.
+ *
+ * @param[in] vm The VM to set the bounds check function for.
+ * @param[in] user_context The user context to pass to the bounds check function.
+ * @param[in] bounds_check The bounds check function.
+ * @retval 0 Success.
+ * @retval -1 Failure.
+ */
+int
+ubpf_register_data_bounds_check(struct ubpf_vm* vm, void* user_context, ubpf_bounds_check bounds_check);
 
 #ifdef __cplusplus
 }

--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -21,7 +21,8 @@
 #define UBPF_H
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #include <ubpf_config.h>
@@ -45,254 +46,265 @@ extern "C" {
 #define UBPF_STACK_SIZE 512
 #endif
 
-/**
- * @brief Opaque type for a the uBPF VM.
- */
-struct ubpf_vm;
+    /**
+     * @brief Opaque type for a the uBPF VM.
+     */
+    struct ubpf_vm;
 
-/**
- * @brief Opaque type for a uBPF JIT compiled function.
- */
-typedef uint64_t (*ubpf_jit_fn)(void* mem, size_t mem_len);
+    /**
+     * @brief Opaque type for a uBPF JIT compiled function.
+     */
+    typedef uint64_t (*ubpf_jit_fn)(void* mem, size_t mem_len);
 
-/**
- * @brief Create a new uBPF VM.
- *
- * @return A pointer to the new VM, or NULL on failure.
- */
-struct ubpf_vm*
-ubpf_create(void);
+    /**
+     * @brief Create a new uBPF VM.
+     *
+     * @return A pointer to the new VM, or NULL on failure.
+     */
+    struct ubpf_vm*
+    ubpf_create(void);
 
-/**
- * @brief Free a uBPF VM.
- *
- * @param[in] vm The VM to free.
- */
-void
-ubpf_destroy(struct ubpf_vm* vm);
+    /**
+     * @brief Free a uBPF VM.
+     *
+     * @param[in] vm The VM to free.
+     */
+    void
+    ubpf_destroy(struct ubpf_vm* vm);
 
-/**
- * @brief Enable / disable bounds_check. Bounds check is enabled by default, but it may be too restrictive.
- *
- * @param[in] vm The VM to enable / disable bounds check on.
- * @param[in] enable Enable bounds check if true, disable if false.
- * @retval true Bounds check was previously enabled.
- */
-bool
-ubpf_toggle_bounds_check(struct ubpf_vm* vm, bool enable);
+    /**
+     * @brief Enable / disable bounds_check. Bounds check is enabled by default, but it may be too restrictive.
+     *
+     * @param[in] vm The VM to enable / disable bounds check on.
+     * @param[in] enable Enable bounds check if true, disable if false.
+     * @retval true Bounds check was previously enabled.
+     */
+    bool
+    ubpf_toggle_bounds_check(struct ubpf_vm* vm, bool enable);
 
-/**
- * @brief Set the function to be invoked if the program hits a fatal error.
- *
- * @param[in] vm The VM to set the error function on.
- * @param[in] error_printf The function to be invoked on fatal error.
- */
-void
-ubpf_set_error_print(struct ubpf_vm* vm, int (*error_printf)(FILE* stream, const char* format, ...));
+    /**
+     * @brief Set the function to be invoked if the program hits a fatal error.
+     *
+     * @param[in] vm The VM to set the error function on.
+     * @param[in] error_printf The function to be invoked on fatal error.
+     */
+    void
+    ubpf_set_error_print(struct ubpf_vm* vm, int (*error_printf)(FILE* stream, const char* format, ...));
 
-/**
- * @brief Register an external function.
- * The immediate field of a CALL instruction is an index into an array of
- * functions registered by the user. This API associates a function with
- * an index.
- *
- * @param[in] vm The VM to register the function on.
- * @param[in] index The index to register the function at.
- * @param[in] name The human readable name of the function.
- * @param[in] fn The function to register.
- * @retval 0 Success.
- * @retval -1 Failure.
- */
-int
-ubpf_register(struct ubpf_vm* vm, unsigned int index, const char* name, void* fn);
+    /**
+     * @brief Register an external function.
+     * The immediate field of a CALL instruction is an index into an array of
+     * functions registered by the user. This API associates a function with
+     * an index.
+     *
+     * @param[in] vm The VM to register the function on.
+     * @param[in] index The index to register the function at.
+     * @param[in] name The human readable name of the function.
+     * @param[in] fn The function to register.
+     * @retval 0 Success.
+     * @retval -1 Failure.
+     */
+    int
+    ubpf_register(struct ubpf_vm* vm, unsigned int index, const char* name, void* fn);
 
-/**
- * @brief Load code into a VM.
- * This must be done before calling ubpf_exec or ubpf_compile and after
- * registering all functions.
- *
- * 'code' should point to eBPF bytecodes and 'code_len' should be the size in
- * bytes of that buffer.
- *
- * @param[in] vm The VM to load the code into.
- * @param[in] code The eBPF bytecodes to load.
- * @param[in] code_len The length of the eBPF bytecodes.
- * @param[out] errmsg The error message, if any. This should be freed by the caller.
- * @retval 0 Success.
- * @retval -1 Failure.
- */
-int
-ubpf_load(struct ubpf_vm* vm, const void* code, uint32_t code_len, char** errmsg);
+    /**
+     * @brief Load code into a VM.
+     * This must be done before calling ubpf_exec or ubpf_compile and after
+     * registering all functions.
+     *
+     * 'code' should point to eBPF bytecodes and 'code_len' should be the size in
+     * bytes of that buffer.
+     *
+     * @param[in] vm The VM to load the code into.
+     * @param[in] code The eBPF bytecodes to load.
+     * @param[in] code_len The length of the eBPF bytecodes.
+     * @param[out] errmsg The error message, if any. This should be freed by the caller.
+     * @retval 0 Success.
+     * @retval -1 Failure.
+     */
+    int
+    ubpf_load(struct ubpf_vm* vm, const void* code, uint32_t code_len, char** errmsg);
 
-/*
- * Unload code from a VM
- *
- * This must be done before calling ubpf_load or ubpf_load_elf, except for the
- * first time those functions are called. It clears the VM instructions to
- * allow for new code to be loaded.
- *
- * It does not unregister any external functions.
- */
+    /*
+     * Unload code from a VM
+     *
+     * This must be done before calling ubpf_load or ubpf_load_elf, except for the
+     * first time those functions are called. It clears the VM instructions to
+     * allow for new code to be loaded.
+     *
+     * It does not unregister any external functions.
+     */
 
-/**
- * @brief Unload code from a VM.
- *
- * The VM must be reloaded with code before calling ubpf_exec or ubpf_compile.
- *
- * @param[in] vm The VM to unload the code from.
- */
-void
-ubpf_unload_code(struct ubpf_vm* vm);
+    /**
+     * @brief Unload code from a VM.
+     *
+     * The VM must be reloaded with code before calling ubpf_exec or ubpf_compile.
+     *
+     * @param[in] vm The VM to unload the code from.
+     */
+    void
+    ubpf_unload_code(struct ubpf_vm* vm);
 
 #if defined(UBPF_HAS_ELF_H)
-/**
- * @brief Load code from an ELF file.
+    /**
+     * @brief Load code from an ELF file.
 
- * This must be done before calling ubpf_exec or ubpf_compile and after
- * registering all functions.
- *
- * 'elf' should point to a copy of an ELF file in memory and 'elf_len' should
- * be the size in bytes of that buffer.
- *
- * The ELF file must be 64-bit little-endian with a single text section
- * containing the eBPF bytecodes. This is compatible with the output of
- * Clang.
- *
- * @param[in] vm The VM to load the code into.
- * @param[in] elf A pointer to a copy of an ELF file in memory.
- * @param[in] elf_len The size of the ELF file.
- * @param[out] errmsg The error message, if any. This should be freed by the caller.
- * @retval 0 Success.
- * @retval -1 Failure.
- */
-int
-ubpf_load_elf(struct ubpf_vm* vm, const void* elf, size_t elf_len, char** errmsg);
+     * This must be done before calling ubpf_exec or ubpf_compile and after
+     * registering all functions.
+     *
+     * 'elf' should point to a copy of an ELF file in memory and 'elf_len' should
+     * be the size in bytes of that buffer.
+     *
+     * The ELF file must be 64-bit little-endian with a single text section
+     * containing the eBPF bytecodes. This is compatible with the output of
+     * Clang.
+     *
+     * @param[in] vm The VM to load the code into.
+     * @param[in] elf A pointer to a copy of an ELF file in memory.
+     * @param[in] elf_len The size of the ELF file.
+     * @param[out] errmsg The error message, if any. This should be freed by the caller.
+     * @retval 0 Success.
+     * @retval -1 Failure.
+     */
+    int
+    ubpf_load_elf(struct ubpf_vm* vm, const void* elf, size_t elf_len, char** errmsg);
 #endif
 
-/**
- * @brief Execute a BPF program in the VM using the interpreter.
- *
- * A program must be loaded into the VM and all external functions must be
- * registered before calling this function.
- *
- * @param[in] vm The VM to execute the program in.
- * @param[in] mem The memory to pass to the program.
- * @param[in] mem_len The length of the memory.
- * @param[in] bpf_return_value The value of the r0 register when the program exits.
- * @retval 0 Success.
- * @retval -1 Failure.
- */
-int
-ubpf_exec(const struct ubpf_vm* vm, void* mem, size_t mem_len, uint64_t* bpf_return_value);
+    /**
+     * @brief Execute a BPF program in the VM using the interpreter.
+     *
+     * A program must be loaded into the VM and all external functions must be
+     * registered before calling this function.
+     *
+     * @param[in] vm The VM to execute the program in.
+     * @param[in] mem The memory to pass to the program.
+     * @param[in] mem_len The length of the memory.
+     * @param[in] bpf_return_value The value of the r0 register when the program exits.
+     * @retval 0 Success.
+     * @retval -1 Failure.
+     */
+    int
+    ubpf_exec(const struct ubpf_vm* vm, void* mem, size_t mem_len, uint64_t* bpf_return_value);
 
-/**
- * @brief Compile a BPF program in the VM to native code.
- *
- * A program must be loaded into the VM and all external functions must be
- * registered before calling this function.
- *
- * @param[in] vm The VM to compile the program in.
- * @param[out] errmsg The error message, if any. This should be freed by the caller.
- * @return ubpf_jit_fn A pointer to the compiled program, or NULL on failure.
- */
-ubpf_jit_fn
-ubpf_compile(struct ubpf_vm* vm, char** errmsg);
+    /**
+     * @brief Compile a BPF program in the VM to native code.
+     *
+     * A program must be loaded into the VM and all external functions must be
+     * registered before calling this function.
+     *
+     * @param[in] vm The VM to compile the program in.
+     * @param[out] errmsg The error message, if any. This should be freed by the caller.
+     * @return ubpf_jit_fn A pointer to the compiled program, or NULL on failure.
+     */
+    ubpf_jit_fn
+    ubpf_compile(struct ubpf_vm* vm, char** errmsg);
 
-/*
- * Translate the eBPF byte code to x64 machine code, store in buffer, and
- * write the resulting count of bytes to size.
- *
- * This must be called after registering all functions.
- *
- * Returns 0 on success, -1 on error. In case of error a pointer to the error
- * message will be stored in 'errmsg' and should be freed by the caller.
- */
+    /*
+     * Translate the eBPF byte code to x64 machine code, store in buffer, and
+     * write the resulting count of bytes to size.
+     *
+     * This must be called after registering all functions.
+     *
+     * Returns 0 on success, -1 on error. In case of error a pointer to the error
+     * message will be stored in 'errmsg' and should be freed by the caller.
+     */
 
-/**
- * @brief Translate the eBPF byte code to x64 machine code.
- *
- * A program must be loaded into the VM and all external functions must be
- * registered before calling this function.
- *
- * @param[in] vm The VM to translate the program in.
- * @param[out] buffer The buffer to store the translated code in.
- * @param[in] size The size of the buffer.
- * @param[out] errmsg The error message, if any. This should be freed by the caller.
- * @retval 0 Success.
- * @retval -1 Failure.
- */
-int
-ubpf_translate(struct ubpf_vm* vm, uint8_t* buffer, size_t* size, char** errmsg);
+    /**
+     * @brief Translate the eBPF byte code to x64 machine code.
+     *
+     * A program must be loaded into the VM and all external functions must be
+     * registered before calling this function.
+     *
+     * @param[in] vm The VM to translate the program in.
+     * @param[out] buffer The buffer to store the translated code in.
+     * @param[in] size The size of the buffer.
+     * @param[out] errmsg The error message, if any. This should be freed by the caller.
+     * @retval 0 Success.
+     * @retval -1 Failure.
+     */
+    int
+    ubpf_translate(struct ubpf_vm* vm, uint8_t* buffer, size_t* size, char** errmsg);
 
-/**
- * @brief Instruct the uBPF runtime to apply unwind-on-success semantics to a helper function.
- * If the function returns 0, the uBPF runtime will end execution of
- * the eBPF program and immediately return control to the caller. This is used
- * for implementing function like the "bpf_tail_call" helper.
- *
- * @param[in] vm The VM to set the unwind helper in.
- * @param[in] idx Index of the helper function to unwind on success.
- * @retval 0 Success.
- * @retval -1 Failure.
- */
-int
-ubpf_set_unwind_function_index(struct ubpf_vm* vm, unsigned int idx);
+    /**
+     * @brief Instruct the uBPF runtime to apply unwind-on-success semantics to a helper function.
+     * If the function returns 0, the uBPF runtime will end execution of
+     * the eBPF program and immediately return control to the caller. This is used
+     * for implementing function like the "bpf_tail_call" helper.
+     *
+     * @param[in] vm The VM to set the unwind helper in.
+     * @param[in] idx Index of the helper function to unwind on success.
+     * @retval 0 Success.
+     * @retval -1 Failure.
+     */
+    int
+    ubpf_set_unwind_function_index(struct ubpf_vm* vm, unsigned int idx);
 
-/**
- * @brief Override the storage location for the BPF registers in the VM.
- *
- * @param[in] vm The VM to set the register storage in.
- * @param[in] regs The register storage.
- */
-void
-ubpf_set_registers(struct ubpf_vm* vm, uint64_t* regs);
+    /**
+     * @brief Override the storage location for the BPF registers in the VM.
+     *
+     * @param[in] vm The VM to set the register storage in.
+     * @param[in] regs The register storage.
+     */
+    void
+    ubpf_set_registers(struct ubpf_vm* vm, uint64_t* regs);
 
-/**
- * @brief Retrieve the storage location for the BPF registers in the VM.
- *
- * @param[in] vm The VM to get the register storage from.
- * @return uint64_t* A pointer to the register storage.
- */
-uint64_t*
-ubpf_get_registers(const struct ubpf_vm* vm);
+    /**
+     * @brief Retrieve the storage location for the BPF registers in the VM.
+     *
+     * @param[in] vm The VM to get the register storage from.
+     * @return uint64_t* A pointer to the register storage.
+     */
+    uint64_t*
+    ubpf_get_registers(const struct ubpf_vm* vm);
 
-/**
- * @brief Optional secret to improve ROP protection.
- *
- * @param[in] vm The VM to set the secret for.
- * @param[in] secret Optional secret to improve ROP protection.
- * Returns 0 on success, -1 on error (e.g. if the secret is set after
- * the instructions are loaded).
- */
-int
-ubpf_set_pointer_secret(struct ubpf_vm* vm, uint64_t secret);
+    /**
+     * @brief Optional secret to improve ROP protection.
+     *
+     * @param[in] vm The VM to set the secret for.
+     * @param[in] secret Optional secret to improve ROP protection.
+     * Returns 0 on success, -1 on error (e.g. if the secret is set after
+     * the instructions are loaded).
+     */
+    int
+    ubpf_set_pointer_secret(struct ubpf_vm* vm, uint64_t secret);
 
-typedef uint64_t (*ubpf_data_relocation)(
-    void* user_context, const uint8_t* data, uint64_t data_size, const char* symbol_name);
+    /**
+     * @brief Data relocation function that is called by the VM when it encounters a
+     * R_BPF_64_64 relocation in the maps section of the ELF file.
+     *
+     * @param[in] user_context The user context that was passed to ubpf_register_data_relocation.
+     * @param[in] data Pointer to referenced data in the maps section of the ELF file.
+     * @param[in] data_size Size of the referenced data.
+     * @param[in] symbol_name Name of the symbol that is referenced.
+     * @param[in] symbol_offset Offset of the symbol relative to the start of the map section.
+     * @return uint64_t The value to insert into the BPF program.
+     */
+    typedef uint64_t (*ubpf_data_relocation)(
+        void* user_context, const uint8_t* data, uint64_t data_size, const char* symbol_name, uint64_t symbol_offset);
 
-/**
- * @brief Set a relocation function for the VM.
- *
- * @param[in] vm The VM to set the relocation function for.
- * @param[in] relocation The relocation function.
- * @return int The value to insert into the BPF program.
- */
-int
-ubpf_register_data_relocation(struct ubpf_vm* vm, void* user_context, ubpf_data_relocation relocation);
+    /**
+     * @brief Set a relocation function for the VM.
+     *
+     * @param[in] vm The VM to set the relocation function for.
+     * @param[in] relocation The relocation function.
+     * @return int The value to insert into the BPF program.
+     */
+    int
+    ubpf_register_data_relocation(struct ubpf_vm* vm, void* user_context, ubpf_data_relocation relocation);
 
-typedef bool (*ubpf_bounds_check)(void* context, uint64_t addr, uint64_t size);
+    typedef bool (*ubpf_bounds_check)(void* context, uint64_t addr, uint64_t size);
 
-/**
- * @brief Set a bounds check function for the VM.
- *
- * @param[in] vm The VM to set the bounds check function for.
- * @param[in] user_context The user context to pass to the bounds check function.
- * @param[in] bounds_check The bounds check function.
- * @retval 0 Success.
- * @retval -1 Failure.
- */
-int
-ubpf_register_data_bounds_check(struct ubpf_vm* vm, void* user_context, ubpf_bounds_check bounds_check);
+    /**
+     * @brief Set a bounds check function for the VM.
+     *
+     * @param[in] vm The VM to set the bounds check function for.
+     * @param[in] user_context The user context to pass to the bounds check function.
+     * @param[in] bounds_check The bounds check function.
+     * @retval 0 Success.
+     * @retval -1 Failure.
+     */
+    int
+    ubpf_register_data_bounds_check(struct ubpf_vm* vm, void* user_context, ubpf_bounds_check bounds_check);
 
 #ifdef __cplusplus
 }

--- a/vm/test.c
+++ b/vm/test.c
@@ -1,3 +1,6 @@
+// Copyright (c) 2015 Big Switch Networks, Inc
+// SPDX-License-Identifier: Apache-2.0
+
 /*
  * Copyright 2015 Big Switch Networks, Inc
  * Copyright 2017 Google Inc.
@@ -29,6 +32,8 @@
 #include <math.h>
 #include "ubpf.h"
 
+#include "../bpf/bpf.h"
+
 #if defined(UBPF_HAS_ELF_H)
 #include <elf.h>
 #endif
@@ -53,6 +58,73 @@ usage(const char* name)
     fprintf(stderr, "  -U, --unload: unload the code and reload it (for testing only)\n");
     fprintf(
         stderr, "  -R, --reload: reload the code, without unloading it first (for testing only, this should fail)\n");
+}
+
+typedef struct _map_entry
+{
+    struct bpf_map_def map_definition;
+    const char* map_name;
+    union
+    {
+        uint8_t* array;
+    };
+} map_entry_t;
+
+static map_entry_t* _map_entries = NULL;
+static int _map_entries_count = 0;
+static int _map_entries_capacity = 0;
+
+uint64_t
+map_relocation(void* user_context, const uint8_t* map_data, uint64_t map_data_size, const char* symbol_name)
+{
+    struct bpf_map_def map_definition = *(struct bpf_map_def*)map_data;
+    (void)user_context; // unused
+
+    if (map_data_size < sizeof(struct bpf_map_def)) {
+        fprintf(stderr, "Invalid map size: %d\n", (int)map_data_size);
+        return 0;
+    }
+
+    if (map_definition.type != BPF_MAP_TYPE_ARRAY) {
+        fprintf(stderr, "Unsupported map type %d\n", map_definition.type);
+        return 0;
+    }
+
+    if (map_definition.key_size != sizeof(uint32_t)) {
+        fprintf(stderr, "Unsupported key size %d\n", map_definition.key_size);
+        return 0;
+    }
+
+    for (int index = 0; index < _map_entries_count; index++) {
+        if (strcmp(_map_entries[index].map_name, symbol_name) == 0) {
+            return (uint64_t)&_map_entries[index];
+        }
+    }
+
+    if (_map_entries_count == _map_entries_capacity) {
+        _map_entries_capacity = _map_entries_capacity ? _map_entries_capacity * 2 : 4;
+        _map_entries = realloc(_map_entries, _map_entries_capacity * sizeof(map_entry_t));
+    }
+
+    _map_entries[_map_entries_count].map_definition = map_definition;
+    _map_entries[_map_entries_count].map_name = strdup(symbol_name);
+    _map_entries[_map_entries_count].array = calloc(map_definition.max_entries, map_definition.value_size);
+
+    return (uint64_t)&_map_entries[_map_entries_count++];
+}
+
+bool
+bounds_check_function(void* user_context, uint64_t addr, uint64_t size)
+{
+    (void)user_context;
+    for (int index = 0; index < _map_entries_count; index++) {
+        if (addr >= (uint64_t)_map_entries[index].array &&
+            addr + size <= (uint64_t)_map_entries[index].array + _map_entries[index].map_definition.max_entries *
+                                                                     _map_entries[index].map_definition.value_size) {
+            return true;
+        }
+    }
+    return false;
 }
 
 int
@@ -135,6 +207,9 @@ main(int argc, char** argv)
         fprintf(stderr, "Failed to create VM\n");
         return 1;
     }
+
+    ubpf_register_data_relocation(vm, NULL, map_relocation);
+    ubpf_register_data_bounds_check(vm, NULL, bounds_check_function);
 
     if (ubpf_set_pointer_secret(vm, secret) != 0) {
         fprintf(stderr, "Failed to set pointer secret\n");
@@ -316,6 +391,63 @@ unwind(uint64_t i)
     return i;
 }
 
+static void*
+bpf_map_lookup_elem_impl(struct bpf_map* map, const void* key)
+{
+    map_entry_t* map_entry = (map_entry_t*)map;
+    if (map_entry->map_definition.type == BPF_MAP_TYPE_ARRAY) {
+        uint32_t index = *(uint32_t*)key;
+        if (index >= map_entry->map_definition.max_entries) {
+            return NULL;
+        }
+        return map_entry->array + index * map_entry->map_definition.value_size;
+    } else {
+        fprintf(stderr, "bpf_map_lookup_elem not implemented for this map type.\n");
+        exit(1);
+    }
+    return NULL;
+}
+
+static int
+bpf_map_update_elem_impl(struct bpf_map* map, const void* key, const void* value, uint64_t flags)
+{
+    map_entry_t* map_entry = (map_entry_t*)map;
+    (void)flags; // unused
+    if (map_entry->map_definition.type == BPF_MAP_TYPE_ARRAY) {
+        uint32_t index = *(uint32_t*)key;
+        if (index >= map_entry->map_definition.max_entries) {
+            return -1;
+        }
+        memcpy(
+            map_entry->array + index * map_entry->map_definition.value_size,
+            value,
+            map_entry->map_definition.value_size);
+        return 0;
+    } else {
+        fprintf(stderr, "bpf_map_update_elem not implemented for this map type.\n");
+        exit(1);
+    }
+    return 0;
+}
+
+static int
+bpf_map_delete_elem_impl(struct bpf_map* map, const void* key)
+{
+    map_entry_t* map_entry = (map_entry_t*)map;
+    if (map_entry->map_definition.type == BPF_MAP_TYPE_ARRAY) {
+        uint32_t index = *(uint32_t*)key;
+        if (index >= map_entry->map_definition.max_entries) {
+            return -1;
+        }
+        memset(
+            map_entry->array + index * map_entry->map_definition.value_size, 0, map_entry->map_definition.value_size);
+        return 0;
+    } else {
+        fprintf(stderr, "bpf_map_delete_elem not implemented for this map type.\n");
+        exit(1);
+    }
+}
+
 static void
 register_functions(struct ubpf_vm* vm)
 {
@@ -326,4 +458,7 @@ register_functions(struct ubpf_vm* vm)
     ubpf_register(vm, 4, "strcmp_ext", strcmp);
     ubpf_register(vm, 5, "unwind", unwind);
     ubpf_set_unwind_function_index(vm, 5);
+    ubpf_register(vm, (unsigned int)(uintptr_t)bpf_map_lookup_elem, "bpf_map_lookup_elem", bpf_map_lookup_elem_impl);
+    ubpf_register(vm, (unsigned int)(uintptr_t)bpf_map_update_elem, "bpf_map_update_elem", bpf_map_update_elem_impl);
+    ubpf_register(vm, (unsigned int)(uintptr_t)bpf_map_delete_elem, "bpf_map_delete_elem", bpf_map_delete_elem_impl);
 }

--- a/vm/test.c
+++ b/vm/test.c
@@ -83,7 +83,8 @@ map_relocation(
     uint64_t symbol_offset)
 {
     struct bpf_map_def map_definition = *(struct bpf_map_def*)map_data;
-    (void)user_context; // unused
+    (void)user_context;  // unused
+    (void)symbol_offset; // unused
 
     if (map_data_size < sizeof(struct bpf_map_def)) {
         fprintf(stderr, "Invalid map size: %d\n", (int)map_data_size);

--- a/vm/test.c
+++ b/vm/test.c
@@ -75,7 +75,12 @@ static int _map_entries_count = 0;
 static int _map_entries_capacity = 0;
 
 uint64_t
-map_relocation(void* user_context, const uint8_t* map_data, uint64_t map_data_size, const char* symbol_name)
+map_relocation(
+    void* user_context,
+    const uint8_t* map_data,
+    uint64_t map_data_size,
+    const char* symbol_name,
+    uint64_t symbol_offset)
 {
     struct bpf_map_def map_definition = *(struct bpf_map_def*)map_data;
     (void)user_context; // unused

--- a/vm/ubpf_int.h
+++ b/vm/ubpf_int.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2015 Big Switch Networks, Inc
+// SPDX-License-Identifier: Apache-2.0
+
 /*
  * Copyright 2015 Big Switch Networks, Inc
  * Copyright 2022 Linaro Limited
@@ -37,6 +40,10 @@ struct ubpf_vm
     int (*translate)(struct ubpf_vm* vm, uint8_t* buffer, size_t* size, char** errmsg);
     int unwind_stack_extension_index;
     uint64_t pointer_secret;
+    ubpf_data_relocation data_relocation_function;
+    void* data_relocation_user_data;
+    ubpf_bounds_check bounds_check_function;
+    void* bounds_check_user_data;
 #ifdef DEBUG
     uint64_t* regs;
 #endif

--- a/vm/ubpf_loader.c
+++ b/vm/ubpf_loader.c
@@ -220,7 +220,7 @@ ubpf_load_elf(struct ubpf_vm* vm, const void* elf, size_t elf_size, char** errms
 
             switch (ELF64_R_TYPE(r.r_info)) {
             // Perform map relocation.
-            case R_BPF_64_64: {
+            case 1: {
                 if (sym.st_shndx > ehdr->e_shnum) {
                     *errmsg = ubpf_error("bad section index");
                     goto error;


### PR DESCRIPTION
Adding support for R_BPF_64_64 relocations via custom callback.

Resolves: #45
Resolves: #54

With this change, uBPF can be used with an external map implementation.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>