### PR TITLE
Update bpf_conformance to the latest

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2022-present, IO Visor Project
+# SPDX-License-Identifier: Apache-2.0
 # All rights reserved.
 #
 # This source code is licensed in accordance with the terms specified in
@@ -199,6 +200,8 @@ jobs:
       run: |
         export BPF_CONFORMANCE_RUNNER="build_bpf_conformance/src/bpf_conformance_runner"
         export BPF_CONFORMANCE_TEST_DIR="--test_file_directory external/bpf_conformance/tests"
+        # Exclude tests that check atomic operations, as they are not supported by uBPF yet.
+        export BPF_CONFORMANCE_TEST_FILTER="--exclude_regex lock"
 
         # For arm64, we need to run the tests in qemu, so use the scripts
         if [[ "${{ inputs.arch }}" == "arm64" ]] ; then
@@ -209,8 +212,8 @@ jobs:
           export BPF_CONFORMANCE_PLUGIN_INTERPRET="--plugin_path build/bin/ubpf_plugin --plugin_options --interpret"
         fi
 
-        ${BPF_CONFORMANCE_RUNNER} ${BPF_CONFORMANCE_TEST_DIR} ${BPF_CONFORMANCE_PLUGIN_JIT}
-        ${BPF_CONFORMANCE_RUNNER} ${BPF_CONFORMANCE_TEST_DIR} ${BPF_CONFORMANCE_PLUGIN_INTERPRET}
+        ${BPF_CONFORMANCE_RUNNER} ${BPF_CONFORMANCE_TEST_DIR} ${BPF_CONFORMANCE_TEST_FILTER} ${BPF_CONFORMANCE_PLUGIN_JIT}
+        ${BPF_CONFORMANCE_RUNNER} ${BPF_CONFORMANCE_TEST_DIR} ${BPF_CONFORMANCE_TEST_FILTER} ${BPF_CONFORMANCE_PLUGIN_INTERPRET}
 
     - name: Generate code coverage report
       if: inputs.enable_coverage == true


### PR DESCRIPTION
Update bpf_conformance to the latest.

Add a filter to exclude atomic BPF operations as they are not supported yet.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>