### PR TITLE
Add support for C++ users

### DIFF
--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -17,6 +17,10 @@
 #ifndef UBPF_H
 #define UBPF_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <ubpf_config.h>
 
 #include <stdio.h>
@@ -259,5 +263,9 @@ ubpf_get_registers(const struct ubpf_vm* vm);
  */
 int
 ubpf_set_pointer_secret(struct ubpf_vm* vm, uint64_t secret);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
In my C++ use case for this library, I currently have 
```c++
extern "C" {
#include <ubpf.h>
}
```
to avoid my C++ compiler mangling the declarations, and then not finding the symbols. This is much like how `ubpf_plugin/ubpf_plugin.cc` does it.
Alternatively, this patch moves the `extern "C"` stuff into ubpf.h itself. As far as I can tell from building the project and running the tests, this has no effect (expectedly) for non-c++ users.