### PR TITLE
Add option to disable JIT compilation

### DIFF
--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -29,6 +29,11 @@ extern "C" {
 #include <stdbool.h>
 
 /**
+ * @brief Option to disable JIT compilation
+ * #define UBPF_DISABLE_JIT
+ */
+
+/**
  * @brief Default maximum number of instructions that a program can contain.
  */
 #if !defined(UBPF_MAX_INSTS)

--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -81,9 +81,9 @@ ubpf_create(void)
     vm->bounds_check_enabled = true;
     vm->error_printf = fprintf;
 
-#if defined(__x86_64__) || defined(_M_X64)
+#if !defined(UBPF_DISABLE_JIT) && (defined(__x86_64__) || defined(_M_X64))
     vm->translate = ubpf_translate_x86_64;
-#elif defined(__aarch64__) || defined(_M_ARM64)
+#elif !defined(UBPF_DISABLE_JIT) && (defined(__aarch64__) || defined(_M_ARM64))
     vm->translate = ubpf_translate_arm64;
 #else
     vm->translate = ubpf_translate_null;


### PR DESCRIPTION
Add option to disable JIT compilation.

eBPF-For-Windows uses the only interpreter in kernel mode, so provide option to exclude references to JIT code.

Resolves: #185 

Signed-off-by: Alan Jowett <alanjo@microsoft.com>