### PR TITLE
Upgrade to Ubuntu 22.04 for testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-22.04
       build_type: RelWithDebInfo
       upload_packages: true
 
@@ -102,14 +102,14 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: arm64
-      platform: ubuntu-20.04
+      platform: ubuntu-22.04
       build_type: RelWithDebInfo
   
   linux_release_scan_build:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-22.04
       build_type: RelWithDebInfo
       scan_build: true
 
@@ -117,7 +117,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-22.04
       build_type: RelWithDebInfo
       enable_coverage: true
 
@@ -125,7 +125,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: arm64
-      platform: ubuntu-20.04
+      platform: ubuntu-22.04
       build_type: RelWithDebInfo
       enable_coverage: true
 
@@ -133,7 +133,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-22.04
       build_type: RelWithDebInfo
       enable_sanitizers: true
 
@@ -142,7 +142,7 @@ jobs:
   #   uses: ./.github/workflows/posix.yml
   #   with:
   #     arch: arm64
-  #     platform: ubuntu-20.04
+  #     platform: ubuntu-22.04
   #     build_type: RelWithDebInfo
   #     enable_sanitizers: true
 
@@ -150,14 +150,14 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-22.04
       build_type: Debug
 
   linux_debug_arm64:
     uses: ./.github/workflows/posix.yml
     with:
       arch: arm64
-      platform: ubuntu-20.04
+      platform: ubuntu-22.04
       build_type: Debug
       upload_packages: true
 
@@ -165,7 +165,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-22.04
       build_type: Debug
       enable_coverage: true
 
@@ -173,7 +173,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: arm64
-      platform: ubuntu-20.04
+      platform: ubuntu-22.04
       build_type: Debug
       enable_coverage: true
 
@@ -181,7 +181,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-22.04
       build_type: Debug
       enable_sanitizers: true
 
@@ -190,7 +190,7 @@ jobs:
   #   uses: ./.github/workflows/posix.yml
   #   with:
   #     arch: arm64
-  #     platform: ubuntu-20.04
+  #     platform: ubuntu-22.04
   #     build_type: Debug
   #     enable_sanitizers: true
 
@@ -200,7 +200,7 @@ jobs:
       - macos_debug_coverage
       - linux_release_coverage
       - linux_debug_coverage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Coveralls Finished
       uses: coverallsapp/github-action@1.1.3

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -80,7 +80,7 @@ jobs:
           ccache
 
     - name: Install system dependencies (Linux)
-      if: inputs.platform == 'ubuntu-20.04'
+      if: inputs.platform == 'ubuntu-22.04'
       run: |
         sudo apt-get install -y \
           ccache \
@@ -239,7 +239,7 @@ jobs:
           --target install
 
     - name: Generate the DEB package
-      if: inputs.platform == 'ubuntu-20.04'
+      if: inputs.platform == 'ubuntu-22.04'
       run: |
         cmake \
           -S . \
@@ -252,7 +252,7 @@ jobs:
           --target package
 
     - name: Generate the RPM package
-      if: inputs.platform == 'ubuntu-20.04'
+      if: inputs.platform == 'ubuntu-22.04'
       run: |
         cmake \
           -S . \
@@ -285,7 +285,7 @@ jobs:
         echo "REL_TGZ_PACKAGE_PATH=$(ls build/*.tar.gz)" >> $GITHUB_OUTPUT
 
     - name: Upload the DEB package
-      if: inputs.upload_packages == true && inputs.platform == 'ubuntu-20.04'
+      if: inputs.upload_packages == true && inputs.platform == 'ubuntu-22.04'
       uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb
       with:
         name: linux_deb_package
@@ -293,7 +293,7 @@ jobs:
         retention-days: 5
 
     - name: Upload the RPM package
-      if: inputs.upload_packages == true && inputs.platform == 'ubuntu-20.04'
+      if: inputs.upload_packages == true && inputs.platform == 'ubuntu-22.04'
       uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb
       with:
         name: linux_rpm_package
@@ -301,7 +301,7 @@ jobs:
         retention-days: 5
 
     - name: Upload the Linux TGZ package
-      if: inputs.upload_packages == true && inputs.platform == 'ubuntu-20.04'
+      if: inputs.upload_packages == true && inputs.platform == 'ubuntu-22.04'
       uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb
       with:
         name: linux_tgz_package


### PR DESCRIPTION
Ubuntu 20.04 runner is no longer able to install the AARCH64 binaries. Seeing if this works on 22.04.


Signed-off-by: Alan Jowett <Alan.Jowett@microsoft.com>