### PR TITLE
See if updating apt catalog fixes missing aarch64 bintools

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -82,6 +82,8 @@ jobs:
     - name: Install system dependencies (Linux)
       if: inputs.platform == 'ubuntu-20.04'
       run: |
+        sudo apt-get update
+
         sudo apt-get install -y \
           ccache \
           ninja-build \


### PR DESCRIPTION
Resolves: #197 

Signed-off-by: Alan Jowett <alanjo@microsoft.com>