### PR TITLE
Add code analysis for ubpf

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,7 +54,8 @@ jobs:
       run: |
         cmake `
           --build build `
-          --config ${{ inputs.build_type }}
+          --config ${{ inputs.build_type }} `
+          -- /p:RunCodeAnalysis=true /p:AnalysisOnExternal=false
 
     # Switch this to Docker when a Windows image is available.
     - name: Run the bpf_conformance tests (Windows)

--- a/vm/CMakeLists.txt
+++ b/vm/CMakeLists.txt
@@ -67,6 +67,16 @@ if(PLATFORM_LINUX)
   endif()
 endif()
 
+if (PLATFORM_WINDOWS)
+    target_compile_options("ubpf" PRIVATE
+        /W4
+        /WX
+    )
+    target_compile_definitions("ubpf" PRIVATE
+        "_CRT_SECURE_NO_WARNINGS"
+    )
+endif()
+
 if(UBPF_ENABLE_TESTS)
   add_executable("ubpf_test"
     test.c

--- a/vm/compat/windows/sys/mman.c
+++ b/vm/compat/windows/sys/mman.c
@@ -78,7 +78,7 @@ mmap(void* addr, size_t length, int prot, int flags, int fd, off_t offset)
 int
 munmap(void* addr, size_t length)
 {
-    (void)addr;
+    (void)length;
     if (!VirtualFree(addr, 0, MEM_RELEASE)) {
         fprintf(stderr, "VirtualFree failed with error %d\n", GetLastError());
         return -1;

--- a/vm/ubpf_int.h
+++ b/vm/ubpf_int.h
@@ -37,7 +37,7 @@ struct ubpf_vm
     const char** ext_func_names;
     bool bounds_check_enabled;
     int (*error_printf)(FILE* stream, const char* format, ...);
-    int (*translate)(struct ubpf_vm* vm, uint8_t* buffer, size_t* size, char** errmsg);
+    int (*translate)(struct ubpf_vm* vm, uint8_t* buffer, uint32_t* size, char** errmsg);
     int unwind_stack_extension_index;
     uint64_t pointer_secret;
     ubpf_data_relocation data_relocation_function;
@@ -51,11 +51,11 @@ struct ubpf_vm
 
 /* The various JIT targets.  */
 int
-ubpf_translate_arm64(struct ubpf_vm* vm, uint8_t* buffer, size_t* size, char** errmsg);
+ubpf_translate_arm64(struct ubpf_vm* vm, uint8_t* buffer, uint32_t* size, char** errmsg);
 int
-ubpf_translate_x86_64(struct ubpf_vm* vm, uint8_t* buffer, size_t* size, char** errmsg);
+ubpf_translate_x86_64(struct ubpf_vm* vm, uint8_t* buffer, uint32_t* size, char** errmsg);
 int
-ubpf_translate_null(struct ubpf_vm* vm, uint8_t* buffer, size_t* size, char** errmsg);
+ubpf_translate_null(struct ubpf_vm* vm, uint8_t* buffer, uint32_t* size, char** errmsg);
 
 char*
 ubpf_error(const char* fmt, ...);

--- a/vm/ubpf_jit_arm64.c
+++ b/vm/ubpf_jit_arm64.c
@@ -56,7 +56,7 @@ struct jit_state
     uint32_t exit_loc;
     uint32_t unwind_loc;
     struct jump* jumps;
-    int num_jumps;
+    unsigned int num_jumps;
     uint32_t stack_size;
 };
 
@@ -478,7 +478,7 @@ emit_movewide_immediate(struct jit_state* state, bool sixty_four, enum Registers
      */
     unsigned count0000 = sixty_four ? 0 : 2;
     unsigned countffff = 0;
-    for (unsigned i = 0; i < (sixty_four ? 64 : 32); i += 16) {
+    for (unsigned i = 0; i < (sixty_four ? 64u : 32u); i += 16) {
         uint64_t block = (imm >> i) & 0xffff;
         if (block == 0xffff) {
             ++countffff;
@@ -491,8 +491,8 @@ emit_movewide_immediate(struct jit_state* state, bool sixty_four, enum Registers
     bool invert = (count0000 < countffff);
     enum MoveWideOpcode op = invert ? MW_MOVN : MW_MOVZ;
     uint64_t skip_pattern = invert ? 0xffff : 0;
-    for (unsigned i = 0; i < (sixty_four ? 4 : 2); ++i) {
-        uint64_t imm16 = (imm >> (i * 16)) & 0xffff;
+    for (unsigned i = 0; i < (sixty_four ? 4u : 2u); ++i) {
+        uint32_t imm16 = (imm >> (i * 16)) & 0xffff;
         if (imm16 != skip_pattern) {
             if (invert) {
                 imm16 = ~imm16;
@@ -586,7 +586,7 @@ emit_function_epilogue(struct jit_state* state)
     }
 
     /* Restore callee-saved registers).  */
-    size_t i;
+    int32_t i;
     for (i = 0; i < _countof(callee_saved_registers); i += 2) {
         emit_loadstorepair_immediate(
             state, LSP_LDPX, callee_saved_registers[i], callee_saved_registers[i + 1], SP, (i + 2) * 8);
@@ -865,7 +865,7 @@ to_condition(int opcode)
 static int
 translate(struct ubpf_vm* vm, struct jit_state* state, char** errmsg)
 {
-    int i;
+    uint16_t i;
 
     emit_function_prologue(state, UBPF_STACK_SIZE);
 
@@ -1129,7 +1129,7 @@ resolve_jumps(struct jit_state* state)
 }
 
 int
-ubpf_translate_arm64(struct ubpf_vm* vm, uint8_t* buffer, size_t* size, char** errmsg)
+ubpf_translate_arm64(struct ubpf_vm* vm, uint8_t* buffer, uint32_t* size, char** errmsg)
 {
     struct jit_state state;
     int result = -1;


### PR DESCRIPTION
Clean up code to be /W4 /WX clean.
Add step to run MSVC code analysis on the codebase.

Resolves: #259