### PR TITLE
Re-enable support for local calls on Windows (x86_64)

### DIFF
--- a/vm/ubpf_int.h
+++ b/vm/ubpf_int.h
@@ -34,6 +34,7 @@ struct ubpf_vm
     ubpf_jit_fn jitted;
     size_t jitted_size;
     ext_func* ext_funcs;
+    bool* int_funcs;
     const char** ext_func_names;
     bool bounds_check_enabled;
     int (*error_printf)(FILE* stream, const char* format, ...);


### PR DESCRIPTION
Re-enabling required properly handling the home space on the stack when using the fastcall calling convention.

Note: There is an open issue about stack alignment requirements now falling on the shoulders of the ebpf compiler (or program writer).