### PR TITLE
Add retpoline mitigation for x86-64 Linux indirect calls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,12 +38,28 @@ jobs:
       build_type: RelWithDebInfo
       upload_packages: true
 
+  windows_release_no_retpolines:
+    uses: ./.github/workflows/windows.yml
+    with:
+      platform: windows-2019
+      build_type: RelWithDebInfo
+      upload_packages: true
+      disable_retpolines: true
+
   windows_debug:
     uses: ./.github/workflows/windows.yml
     with:
       platform: windows-2019
       build_type: Debug
       upload_packages: true
+
+  windows_debug_no_retpolines:
+    uses: ./.github/workflows/windows.yml
+    with:
+      platform: windows-2019
+      build_type: Debug
+      upload_packages: true
+      disable_retpolines: true
 
   macos_release:
     uses: ./.github/workflows/posix.yml
@@ -53,6 +69,15 @@ jobs:
       build_type: RelWithDebInfo
       upload_packages: true
 
+  macos_release_no_retpolines:
+    uses: ./.github/workflows/posix.yml
+    with:
+      arch: x86_64
+      platform: macos-11
+      build_type: RelWithDebInfo
+      upload_packages: true
+      disable_retpolines: true
+
   macos_release_coverage:
     uses: ./.github/workflows/posix.yml
     with:
@@ -60,6 +85,15 @@ jobs:
       platform: macos-11
       build_type: RelWithDebInfo
       enable_coverage: true
+
+  macos_release_coverage_no_retpolines:
+    uses: ./.github/workflows/posix.yml
+    with:
+      arch: x86_64
+      platform: macos-11
+      build_type: RelWithDebInfo
+      enable_coverage: true
+      disable_retpolines: true
 
   macos_release_sanitizers:
     uses: ./.github/workflows/posix.yml
@@ -69,12 +103,31 @@ jobs:
       build_type: RelWithDebInfo
       enable_sanitizers: true
 
+  macos_release_sanitizers_no_retpolines:
+    uses: ./.github/workflows/posix.yml
+    with:
+      arch: x86_64
+      platform: macos-11
+      build_type: RelWithDebInfo
+      enable_sanitizers: true
+      disable_retpolines: true
+
+
   macos_debug:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
       platform: macos-11
       build_type: Debug
+
+  macos_debug_no_retpolines:
+    uses: ./.github/workflows/posix.yml
+    with:
+      arch: x86_64
+      platform: macos-11
+      build_type: Debug
+      disable_retpolines: true
+
 
   macos_debug_coverage:
     uses: ./.github/workflows/posix.yml
@@ -84,6 +137,15 @@ jobs:
       build_type: Debug
       enable_coverage: true
 
+  macos_debug_coverage_no_retpolines:
+    uses: ./.github/workflows/posix.yml
+    with:
+      arch: x86_64
+      platform: macos-11
+      build_type: Debug
+      enable_coverage: true
+      disable_retpolines: true
+
   macos_debug_sanitizers:
     uses: ./.github/workflows/posix.yml
     with:
@@ -91,6 +153,15 @@ jobs:
       platform: macos-11
       build_type: Debug
       enable_sanitizers: true
+
+  macos_debug_sanitizers_no_retpolines:
+    uses: ./.github/workflows/posix.yml
+    with:
+      arch: x86_64
+      platform: macos-11
+      build_type: Debug
+      enable_sanitizers: true
+      disable_retpolines: true
 
   linux_release:
     uses: ./.github/workflows/posix.yml
@@ -115,6 +186,14 @@ jobs:
       build_type: RelWithDebInfo
       scan_build: true
 
+  linux_release_scan_build_no_retpolines:
+    uses: ./.github/workflows/posix.yml
+    with:
+      arch: x86_64
+      platform: ubuntu-20.04
+      build_type: RelWithDebInfo
+      disable_retpolines: true
+
   linux_release_coverage:
     uses: ./.github/workflows/posix.yml
     with:
@@ -122,6 +201,15 @@ jobs:
       platform: ubuntu-20.04
       build_type: RelWithDebInfo
       enable_coverage: true
+
+  linux_release_coverage_no_retpolines:
+    uses: ./.github/workflows/posix.yml
+    with:
+      arch: x86_64
+      platform: ubuntu-20.04
+      build_type: RelWithDebInfo
+      enable_coverage: true
+      disable_retpolines: true
 
   linux_release_arm64_coverage:
     uses: ./.github/workflows/posix.yml
@@ -139,6 +227,15 @@ jobs:
       build_type: RelWithDebInfo
       enable_sanitizers: true
 
+  linux_release_sanitizers_no_retpolines:
+    uses: ./.github/workflows/posix.yml
+    with:
+      arch: x86_64
+      platform: ubuntu-20.04
+      build_type: RelWithDebInfo
+      enable_sanitizers: true
+      disable_retpolines: true
+
   # Disabled until https://github.com/iovisor/ubpf/issues/155 is resolved.
   # linux_release_arm64_sanitizers:
   #   uses: ./.github/workflows/posix.yml
@@ -154,6 +251,14 @@ jobs:
       arch: x86_64
       platform: ubuntu-20.04
       build_type: Debug
+
+  linux_debug_no_retpolines:
+    uses: ./.github/workflows/posix.yml
+    with:
+      arch: x86_64
+      platform: ubuntu-20.04
+      build_type: Debug
+      disable_retpolines: true
 
   linux_debug_arm64:
     uses: ./.github/workflows/posix.yml
@@ -171,6 +276,15 @@ jobs:
       build_type: Debug
       enable_coverage: true
 
+  linux_debug_coverage_no_retpolines:
+    uses: ./.github/workflows/posix.yml
+    with:
+      arch: x86_64
+      platform: ubuntu-20.04
+      build_type: Debug
+      enable_coverage: true
+      disable_retpolines: true
+
   linux_debug_arm64_coverage:
     uses: ./.github/workflows/posix.yml
     with:
@@ -186,6 +300,15 @@ jobs:
       platform: ubuntu-20.04
       build_type: Debug
       enable_sanitizers: true
+
+  linux_debug_sanitizers_no_retpolines:
+    uses: ./.github/workflows/posix.yml
+    with:
+      arch: x86_64
+      platform: ubuntu-20.04
+      build_type: Debug
+      enable_sanitizers: true
+      disable_retpolines: true
 
   # Disabled until https://github.com/iovisor/ubpf/issues/155 is resolved.
   # linux_debug_arm64_sanitizers:

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -51,6 +51,10 @@ on:
         required: false
         type: boolean
 
+      disable_retpolines:
+        required: false
+        type: boolean
+
 jobs:
   build:
     runs-on: ${{ inputs.platform }}
@@ -68,7 +72,7 @@ jobs:
 
     - name: Generate the cache key
       id: cache_key
-      run: echo "VALUE=platform-${{ inputs.platform }}_arch=${{ inputs.arch }}_type-${{ inputs.build_type }}_sanitizers-${{ inputs.enable_sanitizers }}_coverage-${{ inputs.enable_coverage }}_scan_build-${{ inputs.scan_build }}" >> $GITHUB_OUTPUT
+      run: echo "VALUE=platform-${{ inputs.platform }}_arch=${{ inputs.arch }}_type-${{ inputs.build_type }}_sanitizers-${{ inputs.enable_sanitizers }}_coverage-${{ inputs.enable_coverage }}_scan_build-${{ inputs.scan_build }}_retpolines-${{ inputs.disable_retpolines }}" >> $GITHUB_OUTPUT
 
     - name: Update the cache (ccache)
       uses: actions/cache@v3.3.1
@@ -158,6 +162,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} \
           -DUBPF_ENABLE_COVERAGE=${{ inputs.enable_coverage }} \
           -DUBPF_ENABLE_SANITIZERS=${{ inputs.enable_sanitizers }} \
+          -DUBPF_DISABLE_RETPOLINES=${{ inputs.disable_retpolines }} \
           -DUBPF_ENABLE_TESTS=true \
           -DUBPF_ENABLE_INSTALL=true \
           -DUBPF_SKIP_EXTERNAL=true \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,6 +27,10 @@ on:
         required: false
         type: boolean
 
+      disable_retpolines:
+        required: false
+        type: boolean
+
 jobs:
   build:
     runs-on: ${{ inputs.platform }}
@@ -48,6 +52,7 @@ jobs:
           -S . `
           -B build `
           -DUBPF_ENABLE_TESTS=true `
+          -DUBPF_DISABLE_RETPOLINES=${{ inputs.disable_retpolines }} `
           -DUBPF_ENABLE_INSTALL=true
 
     - name: Build uBPF

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -9,6 +9,7 @@
 if(PLATFORM_LINUX OR PLATFORM_MACOS)
   option(UBPF_ENABLE_COVERAGE "Set to true to enable coverage flags")
   option(UBPF_ENABLE_SANITIZERS "Set to true to enable the address and undefined sanitizers")
+  option(UBPF_DISABLE_RETPOLINES "Disable retpoline security on indirect calls and jumps")
 endif()
 
 option(UBPF_ENABLE_INSTALL "Set to true to enable the install targets")

--- a/cmake/settings.cmake
+++ b/cmake/settings.cmake
@@ -30,6 +30,12 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
       )
     endif()
 
+    if(UBPF_DISABLE_RETPOLINES)
+      target_compile_definitions("ubpf_settings" INTERFACE
+        UBPF_DISABLE_RETPOLINES
+      )
+    endif()
+
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
       target_compile_definitions("ubpf_settings" INTERFACE
         DEBUG


### PR DESCRIPTION
Spectre/Meltdown lurk where indirect calls are used. Let's protect against the badness if we can.