### PR TITLE
Remove division-by-zero handling in x86 JIT

### DIFF
--- a/vm/ubpf_jit_x86_64.c
+++ b/vm/ubpf_jit_x86_64.c
@@ -866,8 +866,6 @@ resolve_jumps(struct jit_state* state)
             target_loc = jump.target_offset;
         } else if (jump.target_pc == TARGET_PC_EXIT) {
             target_loc = state->exit_loc;
-        } else if (jump.target_pc == TARGET_PC_DIV_BY_ZERO) {
-            target_loc = state->div_by_zero_loc;
         } else if (jump.target_pc == TARGET_PC_RETPOLINE) {
             target_loc = state->retpoline_loc;
         } else {

--- a/vm/ubpf_jit_x86_64.h
+++ b/vm/ubpf_jit_x86_64.h
@@ -63,7 +63,6 @@ struct jump
 
 /* Special values for target_pc in struct jump */
 #define TARGET_PC_EXIT -1
-#define TARGET_PC_DIV_BY_ZERO -2
 #define TARGET_PC_RETPOLINE -3
 
 struct jit_state
@@ -73,7 +72,6 @@ struct jit_state
     uint32_t size;
     uint32_t* pc_locs;
     uint32_t exit_loc;
-    uint32_t div_by_zero_loc;
     uint32_t unwind_loc;
     uint32_t retpoline_loc;
     struct jump* jumps;


### PR DESCRIPTION
All division by zero is handled by the ISA and does not trigger an exception.