### PR TITLE
Create home space properly for Windows retpolines

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -9,11 +9,9 @@
 if(PLATFORM_LINUX OR PLATFORM_MACOS)
   option(UBPF_ENABLE_COVERAGE "Set to true to enable coverage flags")
   option(UBPF_ENABLE_SANITIZERS "Set to true to enable the address and undefined sanitizers")
-  option(UBPF_DISABLE_RETPOLINES "Disable retpoline security on indirect calls and jumps")
-else()
-    option(UBPF_DISABLE_RETPOLINES "Disable retpoline security on indirect calls and jumps" ON)
 endif()
 
+option(UBPF_DISABLE_RETPOLINES "Disable retpoline security on indirect calls and jumps")
 option(UBPF_ENABLE_INSTALL "Set to true to enable the install targets")
 option(UBPF_ENABLE_TESTS "Set to true to enable tests")
 option(UBPF_ENABLE_PACKAGE "Set to true to enable packaging")

--- a/vm/ubpf_jit_x86_64.c
+++ b/vm/ubpf_jit_x86_64.c
@@ -180,6 +180,12 @@ emit_retpoline(struct jit_state* state)
     /* label2: */
     /* call label0 */
     uint32_t label2 = state->offset;
+#if defined(_WIN32)
+    /*
+     * Make sure that *every* call in Windows has the home space.
+     */
+    emit_alu64_imm32(state, 0x81, 5, RSP, 4 * sizeof(uint64_t));
+#endif
     emit1(state, 0xe8);
     emit_jump_target_offset(state, state->offset, label0);
     emit4(state, 0x00);
@@ -187,6 +193,9 @@ emit_retpoline(struct jit_state* state)
     /*
      * Before leaving this mini-function, restore the proper alignment (see above).
      */
+#if defined(_WIN32)
+    emit_alu64_imm32(state, 0x81, 0, RSP, 4 * sizeof(uint64_t));
+#endif
     emit_alu64_imm32(state, 0x81, 0, RSP, sizeof(uint64_t));
     emit_ret(state);
 


### PR DESCRIPTION
There is a call embedded in the retpoline that also needs home space. It is possible that the final call will need that home space, too. For now, we will go without.