### PR TITLE
Check for return code from tests

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -202,7 +202,13 @@ jobs:
           --target test
 
     - name: Generate code coverage report
-      if: inputs.enable_coverage == true
+      if: inputs.enable_coverage == true && inputs.platform == 'macos-11'
+      run: |
+        mkdir -p coverage
+        lcov --capture --directory build --include '${{env.GITHUB_WORKSPACE}}/*' --output-file coverage/lcov.info --ignore-errors inconsistent
+
+    - name: Generate code coverage report
+      if: inputs.enable_coverage == true && inputs.platform != 'macos-11'
       run: |
         mkdir -p coverage
         lcov --capture --directory build --include '${{env.GITHUB_WORKSPACE}}/*' --output-file coverage/lcov.info

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,9 +67,13 @@ jobs:
         cd .\build\bin\${{ inputs.build_type }}
         $BPF_CONFORMANCE_RUNNER = "..\..\external\bpf_conformance\bin\${{ inputs.build_type }}\bpf_conformance_runner.exe"
         & $BPF_CONFORMANCE_RUNNER --test_file_directory ..\tests --plugin_path ubpf_plugin.exe --plugin_options --jit
+        if ($LastExitCode -ne 0) { throw "Test failed"; }
         & $BPF_CONFORMANCE_RUNNER --test_file_directory ..\tests --plugin_path ubpf_plugin.exe --plugin_options --interpret
+        if ($LastExitCode -ne 0) { throw "Test failed"; }
         & $BPF_CONFORMANCE_RUNNER --exclude lock_ --test_file_directory ..\..\external\bpf_conformance\tests --plugin_path ubpf_plugin.exe --plugin_options --jit
+        if ($LastExitCode -ne 0) { throw "Test failed"; }
         & $BPF_CONFORMANCE_RUNNER --exclude lock_ --test_file_directory ..\..\external\bpf_conformance\tests --plugin_path ubpf_plugin.exe --plugin_options --interpret
+        if ($LastExitCode -ne 0) { throw "Test failed"; }
 
     - name: Generate the TGZ package
       run: |


### PR DESCRIPTION
Add check for return code from bpf_conformance runner and fail CI/CD pipeline if it returns != 0.