### PR TITLE
Add dependency on macos_release/debug_coverage_no_retpolines

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -322,7 +322,9 @@ jobs:
   finish:
     needs:
       - macos_release_coverage
+      - macos_release_coverage_no_retpolines
       - macos_debug_coverage
+      - macos_debug_coverage_no_retpolines
       - linux_release_coverage
       - linux_debug_coverage
       - linux_release_arm64_coverage


### PR DESCRIPTION
CI/CD fails if other jobs complete first. 