### PR TITLE
Fix CI/CD for updated bpf_conformance

### DIFF
--- a/.github/scripts/build-libbpf.sh
+++ b/.github/scripts/build-libbpf.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/bash
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+git clone https://github.com/libbpf/libbpf.git
+if [ $? -ne 0 ]; then
+	echo "Could not clone the libbpf repository."
+	exit 1
+fi
+
+# Jump in to the src directory to do the actual build.
+cd libbpf/src
+
+make
+if [ $? -ne 0 ]; then
+	echo "Could not build libbpf source."
+	exit 1
+fi
+
+# Now that the build was successful, install the library (shared
+# object and header files) in a spot where FindLibBpf.cmake can
+# find it when it is being built.
+sudo PREFIX=/usr LIBDIR=/usr/lib/x86_64-linux-gnu/ make install
+exit 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,7 +167,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-latest
       build_type: RelWithDebInfo
       upload_packages: true
 
@@ -175,14 +175,14 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: arm64
-      platform: ubuntu-20.04
+      platform: ubuntu-latest
       build_type: RelWithDebInfo
 
   linux_release_scan_build:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-latest
       build_type: RelWithDebInfo
       scan_build: true
 
@@ -190,7 +190,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-latest
       build_type: RelWithDebInfo
       disable_retpolines: true
 
@@ -198,7 +198,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-latest
       build_type: RelWithDebInfo
       enable_coverage: true
 
@@ -206,7 +206,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-latest
       build_type: RelWithDebInfo
       enable_coverage: true
       disable_retpolines: true
@@ -215,7 +215,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: arm64
-      platform: ubuntu-20.04
+      platform: ubuntu-latest
       build_type: RelWithDebInfo
       enable_coverage: true
 
@@ -223,7 +223,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-latest
       build_type: RelWithDebInfo
       enable_sanitizers: true
 
@@ -231,7 +231,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-latest
       build_type: RelWithDebInfo
       enable_sanitizers: true
       disable_retpolines: true
@@ -241,7 +241,7 @@ jobs:
   #   uses: ./.github/workflows/posix.yml
   #   with:
   #     arch: arm64
-  #     platform: ubuntu-20.04
+  #     platform: ubuntu-latest
   #     build_type: RelWithDebInfo
   #     enable_sanitizers: true
 
@@ -249,14 +249,14 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-latest
       build_type: Debug
 
   linux_debug_no_retpolines:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-latest
       build_type: Debug
       disable_retpolines: true
 
@@ -264,7 +264,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: arm64
-      platform: ubuntu-20.04
+      platform: ubuntu-latest
       build_type: Debug
       upload_packages: true
 
@@ -272,7 +272,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-latest
       build_type: Debug
       enable_coverage: true
 
@@ -280,7 +280,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-latest
       build_type: Debug
       enable_coverage: true
       disable_retpolines: true
@@ -289,7 +289,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: arm64
-      platform: ubuntu-20.04
+      platform: ubuntu-latest
       build_type: Debug
       enable_coverage: true
 
@@ -297,7 +297,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-latest
       build_type: Debug
       enable_sanitizers: true
 
@@ -305,7 +305,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: ubuntu-20.04
+      platform: ubuntu-latest
       build_type: Debug
       enable_sanitizers: true
       disable_retpolines: true
@@ -315,7 +315,7 @@ jobs:
   #   uses: ./.github/workflows/posix.yml
   #   with:
   #     arch: arm64
-  #     platform: ubuntu-20.04
+  #     platform: ubuntu-latest
   #     build_type: Debug
   #     enable_sanitizers: true
 
@@ -330,7 +330,7 @@ jobs:
       - linux_release_arm64_coverage
       - linux_debug_arm64_coverage
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished
       uses: coverallsapp/github-action@v2.2.3

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -86,7 +86,7 @@ jobs:
           ccache
 
     - name: Install system dependencies (Linux)
-      if: inputs.platform == 'ubuntu-20.04'
+      if: inputs.platform == 'ubuntu-latest'
       run: |
         sudo apt-get update
 
@@ -98,7 +98,7 @@ jobs:
           libboost-dev \
           libboost-program-options-dev \
           libboost-filesystem-dev \
-          libbpf-dev
+          libelf-dev
 
         if [[ "${{ inputs.scan_build }}" == "true" ]] ; then
           sudo apt-get install -y \
@@ -111,6 +111,11 @@ jobs:
             gcc-aarch64-linux-gnu \
             qemu-user
         fi
+
+    - name: Build/install libbpf From Source
+      if: inputs.platform == 'ubuntu-latest'
+      run: ./.github/scripts/build-libbpf.sh
+      shell: bash
 
     - name: Install system dependencies (macOS)
       if: inputs.platform == 'macos-11'
@@ -231,7 +236,7 @@ jobs:
           --target install
 
     - name: Generate the DEB package
-      if: inputs.platform == 'ubuntu-20.04'
+      if: inputs.platform == 'ubuntu-latest'
       run: |
         cmake \
           -S . \
@@ -244,7 +249,7 @@ jobs:
           --target package
 
     - name: Generate the RPM package
-      if: inputs.platform == 'ubuntu-20.04'
+      if: inputs.platform == 'ubuntu-latest'
       run: |
         cmake \
           -S . \
@@ -277,7 +282,7 @@ jobs:
         echo "REL_TGZ_PACKAGE_PATH=$(ls build/*.tar.gz)" >> $GITHUB_OUTPUT
 
     - name: Upload the DEB package
-      if: inputs.upload_packages == true && inputs.platform == 'ubuntu-20.04'
+      if: inputs.upload_packages == true && inputs.platform == 'ubuntu-latest'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
       with:
         name: linux_deb_package
@@ -285,7 +290,7 @@ jobs:
         retention-days: 5
 
     - name: Upload the RPM package
-      if: inputs.upload_packages == true && inputs.platform == 'ubuntu-20.04'
+      if: inputs.upload_packages == true && inputs.platform == 'ubuntu-latest'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
       with:
         name: linux_rpm_package
@@ -293,7 +298,7 @@ jobs:
         retention-days: 5
 
     - name: Upload the Linux TGZ package
-      if: inputs.upload_packages == true && inputs.platform == 'ubuntu-20.04'
+      if: inputs.upload_packages == true && inputs.platform == 'ubuntu-latest'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
       with:
         name: linux_tgz_package


### PR DESCRIPTION
The updated bpf_conformance requires a new(er) version of libbpf than is available on github runners. With this change, we build our own version of libbpf from source so that we are using a new(er) version of the library with all the necessary features.