### PR TITLE
More External Project Configuration Updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "vm/compat/libraries/win-c/src"]
 	path = vm/compat/libraries/win-c/src
 	url = https://github.com/takamin/win-c
+[submodule "external/bpf_conformance"]
+	path = external/bpf_conformance
+	url = https://github.com/Alan-Jowett/bpf_conformance.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,16 +21,16 @@ if(UBPF_ENABLE_TESTS)
 endif()
 
 add_subdirectory("vm")
+    ExternalProject_Add(Conformance
+        INSTALL_COMMAND ""
+        SOURCE_DIR ${CMAKE_SOURCE_DIR}/external/bpf_conformance
+				BINARY_DIR ${CMAKE_BINARY_DIR}/external/bpf_conformance
+        EXCLUDE_FROM_ALL true
+        STEP_TARGETS build)
 
 if(UBPF_ENABLE_TESTS)
   add_subdirectory("ubpf_plugin")
   if (NOT UBPF_SKIP_EXTERNAL)
-    ExternalProject_Add(Conformance GIT_REPOSITORY "https://github.com/Alan-Jowett/bpf_conformance.git"
-        GIT_SUBMODULES_RECURSE true
-        GIT_TAG main
-        INSTALL_COMMAND ""
-        BINARY_DIR ${CMAKE_BINARY_DIR}/external/bpf_conformance
-        SOURCE_DIR ${CMAKE_SOURCE_DIR}/external/bpf_conformance)
   endif()
   add_subdirectory("bpf")
   add_subdirectory("aarch64_test")

--- a/ubpf_plugin/CMakeLists.txt
+++ b/ubpf_plugin/CMakeLists.txt
@@ -1,6 +1,11 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+if (UBPF_SKIP_EXTERNAL)
+    message(WARNING "Skipping configuration of tests that require external package support.")
+    return()
+endif()
+
 set(CMAKE_CXX_STANDARD 20)
 
 file(COPY ${CMAKE_SOURCE_DIR}/tests DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
@@ -9,6 +14,8 @@ add_executable(
     ubpf_plugin
     ubpf_plugin.cc
 )
+
+add_dependencies(ubpf_plugin Conformance-build)
 
 target_include_directories("ubpf_plugin" PRIVATE
     "${CMAKE_SOURCE_DIR}/vm"


### PR DESCRIPTION
1. Make sure that tests that require external packages do not try to build when the user has opted out of external packages.
2. Integrate git submodules with external projects (CMake) for the best of both worlds!