### PR TITLE
Fix ubpf_plugin passing ambiguous pointer to memory for ubpf_exec

### DIFF
--- a/tests/mul-loop-memory-iterations.data
+++ b/tests/mul-loop-memory-iterations.data
@@ -1,0 +1,12 @@
+-- asm
+mov %r0, 0x7
+ldxw %r1, [%r1]
+add %r1, 0x2
+mul %r0, 0x7
+add %r1, 0xffffffff
+jne %r1, 0x0, -3
+exit
+-- mem
+00 00 00 00
+-- result
+0x157

--- a/ubpf_plugin/ubpf_plugin.cc
+++ b/ubpf_plugin/ubpf_plugin.cc
@@ -115,6 +115,11 @@ int main(int argc, char **argv)
 
     std::vector<ebpf_inst> program = bytes_to_ebpf_inst(base16_decode(program_string));
     std::vector<uint8_t> memory = base16_decode(memory_string);
+    uint8_t *memory_ptr{nullptr};
+
+    if (memory.size() != 0) {
+        memory_ptr = memory.data();
+    }
 
     std::unique_ptr<ubpf_vm, decltype(&ubpf_destroy)> vm(ubpf_create(), ubpf_destroy);
     char* error = nullptr;
@@ -159,11 +164,11 @@ int main(int argc, char **argv)
             free(error);
             return 1;
         }
-        actual_result = fn(memory.data(), memory.size());
+        actual_result = fn(memory_ptr, memory.size());
     }
     else
     {
-        if (ubpf_exec(vm.get(), memory.data(), memory.size(), &actual_result) != 0)
+        if (ubpf_exec(vm.get(), memory_ptr, memory.size(), &actual_result) != 0)
         {
             std::cerr << "Failed to execute program" << std::endl;
             return 1;


### PR DESCRIPTION
When there is no user-specified starting contents for the memory when using ubpf_plugin, the vector representing the contents of the memory is empty. There was an assumption that when the size of a std::vector is 0 then std::vector::data will return a null pointer but this is not guaranteed to be the case.

Issue found while trying to debug tests/mul-loop.data failure in wasm platform.