### PR TITLE
Prevent division by 0

### DIFF
--- a/tests/div32-by-zero-reg.data
+++ b/tests/div32-by-zero-reg.data
@@ -1,0 +1,7 @@
+-- asm
+mov32 %r0, 1
+lddw %r1, 0x100000000
+div32 %r0, %r1
+exit
+-- result
+0x0

--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -368,7 +368,7 @@ ubpf_exec(const struct ubpf_vm* vm, void* mem, size_t mem_len, uint64_t* bpf_ret
             reg[inst.dst] &= UINT32_MAX;
             break;
         case EBPF_OP_DIV_REG:
-            reg[inst.dst] = reg[inst.src] ? u32(reg[inst.dst]) / u32(reg[inst.src]) : 0;
+            reg[inst.dst] = u32(reg[inst.src]) ? u32(reg[inst.dst]) / u32(reg[inst.src]) : 0;
             reg[inst.dst] &= UINT32_MAX;
             break;
         case EBPF_OP_OR_IMM:


### PR DESCRIPTION
When checking whether the operand is not 0, one should only look on 32 bits when doing a 32 bits operation.