### PR TITLE
Reject BPF programs with jump targets outside of range of instructions.

### DIFF
--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -1118,7 +1118,7 @@ validate(const struct ubpf_vm* vm, const struct ebpf_inst* insts, uint32_t num_i
                 }
             } else if (inst.src == 1) {
                 int call_target = i + (inst.imm + 1);
-                if (call_target < 0 || call_target > num_insts) {
+                if (call_target < 0 || call_target >= num_insts) {
                     *errmsg =
                         ubpf_error("call to local function (at PC %d) is out of bounds (target: %d)", i, call_target);
                     return false;


### PR DESCRIPTION
This pull request includes a crucial change to the `validate` function in the `vm/ubpf_vm.c` file. The condition checking the `call_target` variable has been updated to prevent out-of-bounds access. Previously, the condition allowed for `call_target` to be equal to `num_insts`, which could potentially lead to accessing an element beyond the array's limit. Now, the condition has been corrected to `call_target >= num_insts`, ensuring that `call_target` stays within the valid range of array indices.