### PR TITLE
Add libfuzzer based test with 

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -152,6 +152,7 @@ jobs:
         git config --global user.email 'ubpf@users.noreply.github.com'
         git config --global user.name 'Github Action'
         git commit -sm "Update fuzzing corpus"
+        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/iovisor/ubpf.git
         git push
 
     - name: Upload artifacts

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,0 +1,162 @@
+# Copyright (c) uBPF contributors
+# SPDX-License-Identifier: MIT
+
+name: Fuzzing
+
+permissions:
+  contents: write # Required to update the corpus
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        description: 'Architecture'
+        required: true
+        type: string
+
+      platform:
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ${{ inputs.platform }}
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+
+    - name: Initialize CodeQL
+      if: inputs.build_codeql == true
+      uses: github/codeql-action/init@d39d31e687223d841ef683f52467bd88e9b21c14
+      with:
+        languages: 'cpp'
+
+    - name: Generate the cache key
+      id: cache_key
+      run: echo "VALUE=platform-${{ inputs.platform }}_arch=${{ inputs.arch }}_type=fuzzing" >> $GITHUB_OUTPUT
+
+    - name: Update the cache (ccache)
+      uses: actions/cache@v4.0.2
+      with:
+        path: ccache
+        key: ${{ steps.cache_key.outputs.VALUE }}_ccache
+
+    - name: Create the build folders
+      run: |
+        mkdir -p \
+          ccache
+
+    - name: Install system dependencies (Linux)
+      if: inputs.platform == 'ubuntu-latest'
+      run: |
+        sudo apt-get update
+
+        sudo apt-get install -y \
+          ccache \
+          ninja-build \
+          cmake \
+          lcov \
+          libboost-dev \
+          libboost-program-options-dev \
+          libboost-filesystem-dev \
+          libelf-dev
+
+        if [[ "${{ inputs.scan_build }}" == "true" ]] ; then
+          sudo apt-get install -y \
+            clang-tools
+        fi
+
+        if [[ "${{ inputs.arch }}" == "arm64" ]] ; then
+          sudo apt install -y \
+            g++-aarch64-linux-gnu \
+            gcc-aarch64-linux-gnu \
+            qemu-user
+        fi
+
+    - name: Build/install libbpf From Source
+      if: inputs.platform == 'ubuntu-latest'
+      run: ./.github/scripts/build-libbpf.sh
+      shell: bash
+
+    - name: Install system dependencies (macOS)
+      if: inputs.platform == 'macos-11'
+      run: |
+        brew install \
+          cmake \
+          ninja \
+          ccache \
+          lcov \
+          boost
+
+    - name: Configure uBPF
+      run: |
+        export CCACHE_DIR="$(pwd)/ccache"
+
+        ${command_prefix} cmake \
+          -G Ninja \
+          -S . \
+          -B build \
+          -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} \
+          -DCMAKE_C_COMPILER=clang \
+          -DCMAKE_CXX_COMPILER=clang++ \
+          -DUBPF_ENABLE_LIBFUZZER=1 \
+          -DCMAKE_BUILD_TYPE=Debug
+          ${arch_flags}
+
+    - name: Build uBPF
+      run: |
+        export CCACHE_DIR="$(pwd)/ccache"
+
+        if [[ "${{ inputs.scan_build }}" == "true" ]] ; then
+          command_prefix="scan-build -o scan_build_report"
+        fi
+
+        ${command_prefix} cmake \
+          --build build
+
+    - name: Upload fuzzer as artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: fuzzer
+        path: build/bin/ubpf_fuzzer
+
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+        ref: fuzz/corpus
+
+    - name: Download fuzzer artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: fuzzer
+
+    - name: Setup directory for fuzzing
+      run: |
+        ls -la
+        mkdir -p new_corpus
+        mkdir -p fuzz/corpus
+        cp -r fuzz/corpus/* new_corpus
+        mkdir -p artifacts
+        chmod a+x ubpf_fuzzer
+
+    - name: Run fuzzing
+      run: |
+        ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=300
+
+    - name: Merge corpus into fuzz/corpus
+      run: |
+        ./ubpf_fuzzer -merge=1 fuzz/corpus new_corpus
+        git add fuzz/corpus
+        git config --global user.email 'ubpf@users.noreply.github.com'
+        git config --global user.name 'Github Action'
+        git commit -sm "Update fuzzing corpus"
+        git push
+
+    - name: Upload artifacts
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: fuzzing-artifacts
+        path: artifacts/

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -4,7 +4,7 @@
 name: Fuzzing
 
 permissions:
-  contents: write # Required to update the corpus
+  contents: read
 
 on:
   workflow_call:
@@ -17,6 +17,11 @@ on:
       platform:
         required: true
         type: string
+
+    secrets:
+        GITHUB_TOKEN:
+          description: 'Token to push changes to the repository'
+          required: true
 
 jobs:
   build:

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -18,11 +18,6 @@ on:
         required: true
         type: string
 
-    secrets:
-        GITHUB_TOKEN:
-          description: 'Token to push changes to the repository'
-          required: true
-
 jobs:
   build:
     runs-on: ${{ inputs.platform }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -310,13 +310,13 @@ jobs:
       enable_sanitizers: true
       disable_retpolines: true
 
+  # Run fuzzing on scheduled task only.
   linux_fuzzing:
+    if: github.event_name == 'schedule'
     uses: ./.github/workflows/fuzzing.yml
     with:
       arch: x86_64
       platform: ubuntu-latest
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Disabled until https://github.com/iovisor/ubpf/issues/155 is resolved.
   # linux_debug_arm64_sanitizers:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@
 name: Main
 
 permissions:
-  contents: read
+  contents: write
   security-events: write # Required by codeql task.
 
 on:
@@ -20,7 +20,7 @@ on:
 
   push:
     branches:
-      - '*'
+      - 'main'
 
   pull_request:
     branches:
@@ -309,6 +309,12 @@ jobs:
       build_type: Debug
       enable_sanitizers: true
       disable_retpolines: true
+
+  linux_fuzzing:
+    uses: ./.github/workflows/fuzzing.yml
+    with:
+      arch: x86_64
+      platform: ubuntu-latest
 
   # Disabled until https://github.com/iovisor/ubpf/issues/155 is resolved.
   # linux_debug_arm64_sanitizers:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@
 name: Main
 
 permissions:
-  contents: write
+  contents: read
   security-events: write # Required by codeql task.
 
 on:
@@ -315,6 +315,8 @@ jobs:
     with:
       arch: x86_64
       platform: ubuntu-latest
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Disabled until https://github.com/iovisor/ubpf/issues/155 is resolved.
   # linux_debug_arm64_sanitizers:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ if(UBPF_ENABLE_PACKAGE)
   include("cmake/packaging.cmake")
 endif()
 
-if (UBPF_ENABLE_LIBFUZZER)
+# Add libfuzzer if UBPF_ENABLE_LIBFUZZER or UBPF_ENABLE_COVERAGE is enabled
+if (UBPF_ENABLE_LIBFUZZER OR UBPF_ENABLE_COVERAGE)
   add_subdirectory("libfuzzer")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,6 @@ if(UBPF_ENABLE_PACKAGE)
   include("cmake/packaging.cmake")
 endif()
 
-# Add libfuzzer if UBPF_ENABLE_LIBFUZZER or UBPF_ENABLE_COVERAGE is enabled
-if (UBPF_ENABLE_LIBFUZZER OR UBPF_ENABLE_COVERAGE)
+if (UBPF_ENABLE_LIBFUZZER)
   add_subdirectory("libfuzzer")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,3 +41,6 @@ if(UBPF_ENABLE_PACKAGE)
   include("cmake/packaging.cmake")
 endif()
 
+if (UBPF_ENABLE_LIBFUZZER)
+  add_subdirectory("libfuzzer")
+endif()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -9,6 +9,7 @@
 if(PLATFORM_LINUX OR PLATFORM_MACOS)
   option(UBPF_ENABLE_COVERAGE "Set to true to enable coverage flags")
   option(UBPF_ENABLE_SANITIZERS "Set to true to enable the address and undefined sanitizers")
+  option(UBPF_ENABLE_LIBFUZZER "Set to true to enable the libfuzzer")
 endif()
 
 option(UBPF_DISABLE_RETPOLINES "Disable retpoline security on indirect calls and jumps")

--- a/cmake/settings.cmake
+++ b/cmake/settings.cmake
@@ -64,6 +64,28 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
       )
     endif()
 
+    if(UBPF_ENABLE_LIBFUZZER)
+      set(fuzzer_flags
+        -g
+        -O0
+        -fsanitize=fuzzer
+        -fsanitize=address
+        -fsanitize-coverage=edge,indirect-calls,trace-cmp,trace-div,trace-gep
+        )
+
+      # Check if compiler is clang and emit error if not
+        if(NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")
+            message(FATAL_ERROR "LibFuzzer is only supported with Clang")
+        endif()
+
+        target_compile_options("ubpf_settings" INTERFACE
+            ${fuzzer_flags}
+        )
+
+        target_link_options("ubpf_settings" INTERFACE
+            ${fuzzer_flags}
+        )
+    endif()
   elseif(PLATFORM_WINDOWS)
     set(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION "8.1")
 

--- a/libfuzzer/CMakeLists.txt
+++ b/libfuzzer/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+if (UBPF_SKIP_EXTERNAL)
+    message(WARNING "Skipping configuration of tests that require external package support.")
+    return()
+endif()
+
+set(CMAKE_CXX_STANDARD 20)
+
+add_executable(
+    ubpf_fuzzer
+    libfuzz_harness.cc
+)
+
+target_include_directories("ubpf_fuzzer" PRIVATE
+    "${CMAKE_SOURCE_DIR}/vm"
+    "${CMAKE_BINARY_DIR}/vm"
+    "${CMAKE_SOURCE_DIR}/vm/inc"
+    "${CMAKE_BINARY_DIR}/vm/inc"
+    "${CMAKE_SOURCE_DIR}/ubpf_plugin"
+)
+
+target_link_libraries(
+    ubpf_fuzzer
+    ubpf
+    ubpf_settings
+)
+

--- a/libfuzzer/libfuzz_harness.cc
+++ b/libfuzzer/libfuzz_harness.cc
@@ -1,0 +1,122 @@
+// Copyright (c) uBPF contributors
+// SPDX-License-Identifier: MIT
+
+#include <cstdint>
+#include <cstddef>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <vector>
+#include <string>
+#include <sstream>
+
+
+extern "C"
+{
+#include "ebpf.h"
+#include "ubpf.h"
+}
+
+#include "test_helpers.h"
+
+uint64_t test_helpers_dispatcher(uint64_t p0, uint64_t p1,uint64_t p2,uint64_t p3, uint64_t p4, unsigned int idx, void* cookie) {
+    UNREFERENCED_PARAMETER(cookie);
+    return helper_functions[idx](p0, p1, p2, p3, p4);
+}
+
+bool test_helpers_validator(unsigned int idx, const struct ubpf_vm *vm) {
+    UNREFERENCED_PARAMETER(vm);
+    return helper_functions.contains(idx);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, std::size_t size);
+
+int null_printf(FILE* stream, const char* format, ...)
+{
+    if (!stream) {
+        return 0;
+    }
+    if (!format) {
+        return 0;
+    }
+    return 0;
+}
+
+/**
+ * @brief Accept an input buffer and size.
+ *
+ * @param[in] data Pointer to the input buffer.
+ * @param[in] size Size of the input buffer.
+ * @return -1 if the input is invalid
+ * @return 0 if the input is valid and processed.
+ */
+int LLVMFuzzerTestOneInput(const uint8_t* data, std::size_t size)
+{
+    // Assume the fuzzer input is as follows:
+    // 32-bit program length
+    // program byte
+    // test data
+
+    // Copy memory into a writable buffer.
+    std::vector<uint8_t> memory;
+
+    if (size < 4)
+        return -1;
+
+    uint32_t program_length = *reinterpret_cast<const uint32_t*>(data);
+    uint32_t memory_length = size - 4 - program_length;
+    const uint8_t* program_start = data + 4;
+    const uint8_t* memory_start = data + 4 + program_length;
+
+    if (program_length > size)
+        return -1;
+
+    if (program_length == 0)
+        return -1;
+
+    if (program_length + 4u > size)
+        return -1;
+
+    // Copy any input memory into a writable buffer.
+    if (memory_length > 0) {
+        memory.resize(memory_length);
+        std::memcpy(memory.data(), memory_start, memory_length);
+    }
+
+    ubpf_vm* vm = ubpf_create();
+    if (vm == nullptr)
+        return -1;
+
+    char* error_message = nullptr;
+
+    if (program_length == 0) {
+        ubpf_destroy(vm);
+        return -1;
+    }
+
+    if (ubpf_load(vm, program_start, program_length, &error_message) != 0) {
+        free(error_message);
+        ubpf_destroy(vm);
+        return -1;
+    }
+
+    ubpf_set_error_print(vm, null_printf);
+
+    ubpf_toggle_bounds_check(vm, true);
+
+    ubpf_register_external_dispatcher(vm, test_helpers_dispatcher, test_helpers_validator);
+
+    ubpf_set_instruction_limit(vm, 10000);
+
+    uint64_t result = 0;
+
+    // Assume the remaining data is test data.
+    if (ubpf_exec(vm, memory.data(), memory.size(), &result) != 0) {
+        ubpf_destroy(vm);
+        return 0;
+    }
+
+    ubpf_destroy(vm);
+
+    return 0; // Non-zero return values are reserved for future use.
+}

--- a/libfuzzer/libfuzz_harness.cc
+++ b/libfuzzer/libfuzz_harness.cc
@@ -116,6 +116,19 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, std::size_t size)
         return 0;
     }
 
+    // TODO: Enable executing the BPF code via JIT.
+    // This is blocked on an unknown issue that causes code to pass when run via
+    // the interpreter, but fail when run via the JIT.
+    //
+    // auto fn = ubpf_compile(vm, &error_message);
+    // if (fn == nullptr) {
+    //     free(error_message);
+    //     ubpf_destroy(vm);
+    //     return 0;
+    // }
+
+    // fn(memory.data(), memory.size());
+
     ubpf_destroy(vm);
 
     return 0; // Non-zero return values are reserved for future use.

--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -415,14 +415,18 @@ extern "C"
     ubpf_set_jit_code_size(struct ubpf_vm* vm, size_t code_size);
 
     /**
-     * @brief Set the instruction limit for the VM.
+     * @brief Set the instruction limit for the VM. This is the maximum number
+     * of instructions that a program may execute during a call to ubpf_exec.
+     * It has no effect on JIT'd programs.
      *
      * @param[in] vm The VM to set the instruction limit for.
      * @param[in] limit The maximum number of instructions that a program may execute or 0 for no limit.
-     * @return Previous instruction limit.
+     * @param[out] previous_limit Optional pointer to store the previous instruction limit.
+     * @return 0 Success.
+     * @return -1 Failure.
      */
     int
-    ubpf_set_instruction_limit(struct ubpf_vm* vm, uint32_t limit);
+    ubpf_set_instruction_limit(struct ubpf_vm* vm, uint32_t limit, uint32_t* previous_limit);
 
 
 #ifdef __cplusplus

--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -414,6 +414,17 @@ extern "C"
     int
     ubpf_set_jit_code_size(struct ubpf_vm* vm, size_t code_size);
 
+    /**
+     * @brief Set the instruction limit for the VM.
+     *
+     * @param[in] vm The VM to set the instruction limit for.
+     * @param[in] limit The maximum number of instructions that a program may execute or 0 for no limit.
+     * @return Previous instruction limit.
+     */
+    int
+    ubpf_set_instruction_limit(struct ubpf_vm* vm, uint32_t limit);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/vm/ubpf_int.h
+++ b/vm/ubpf_int.h
@@ -70,6 +70,7 @@ struct ubpf_vm
     void* data_relocation_user_data;
     ubpf_bounds_check bounds_check_function;
     void* bounds_check_user_data;
+    int instruction_limit;
 #ifdef DEBUG
     uint64_t* regs;
 #endif


### PR DESCRIPTION
This pull request introduces fuzzing capabilities to the project, including a new GitHub Actions workflow, and modifies the project's build system to support fuzzing. The most significant changes include the addition of the `fuzzing.yml` workflow, the introduction of a new `ubpf_fuzzer` executable, and the modification of the `ubpf_vm` structure to include an instruction limit.

New GitHub Actions workflow:

* [`.github/workflows/fuzzing.yml`](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cR1-R162): Added a new workflow to perform fuzzing. This workflow includes steps to build the project with fuzzing enabled, run the fuzzer, and upload any found artifacts.

Modifications to existing GitHub Actions workflow:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L14-R14): Modified the `permissions` field to have write access to contents, changed the `push` and `pull_request` branches to `main` from `*`, and added a job to use the new `fuzzing.yml` workflow. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L14-R14) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L23-R23) [[3]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R313-R318)

Changes to build system:

* `CMakeLists.txt`, `cmake/options.cmake`, `cmake/settings.cmake`: Added options to enable libfuzzer and coverage, and set compiler flags accordingly. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR44-R47) [[2]](diffhunk://#diff-e8bc1b52c7618188b02120d369a4664f177556455e9a3c705d82b2cfd098d9c8R12) [[3]](diffhunk://#diff-f1e9eb7909f178e76caf57d638f4eb36adc09ae055106a11aa0df61d4c357d25R67-R88)

New fuzzer executable:

* `libfuzzer/CMakeLists.txt`, `libfuzzer/libfuzz_harness.cc`: Added a new executable `ubpf_fuzzer` that is built when fuzzing is enabled. This executable uses libfuzzer to fuzz the uBPF virtual machine. [[1]](diffhunk://#diff-1741b861004a93abe82df187da3c41bae7ed269806a0fa9a2ef98eff4e41e04aR1-R29) [[2]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524R1-R135)

Modifications to uBPF VM:

* `vm/inc/ubpf.h`, `vm/ubpf_int.h`, `vm/ubpf_vm.c`: Modified the `ubpf_vm` structure to include an instruction limit, added a method to set this limit, and modified the `ubpf_exec` function to respect this limit. Also, the bounds check function was updated for better error handling and reporting. [[1]](diffhunk://#diff-47050594ea372d3c6a44bce95ada2feb7306a466565cca08aa9458d69cf92b3aR417-R427) [[2]](diffhunk://#diff-ccc2080d6f834b941532da6596afc72b821d21730d00b7f2063485f6cc4646e4R73) [[3]](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fR401-R412) [[4]](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fL1191-R1235) [[5]](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fL1216) [[6]](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fR1358-R1365)