### PR TITLE
Reject BPF program if uninitialized stack or registers are accessed during interpret path

### DIFF
--- a/libfuzzer/README.md
+++ b/libfuzzer/README.md
@@ -62,10 +62,9 @@ artifact_prefix='artifacts/'; Test unit written to artifacts/crash-7036cbef2b568
 Base64: KAAAALRQEGpqSmotLgEAAAAAAAAEIQAAAACVlSYh/P///5WVlZWXt5eXAI4AJA==
 ```
 
-To triage the crash, the crash can be post processed using:
+To triage the crash, post process it with:
 ```
 libfuzzer/split.sh artifacts/crash-7036cbef2b568fa0b6e458a9c8062571a65144e1
-
 
 Extracting program-7036cbef2b568fa0b6e458a9c8062571a65144e1...
 Extracting memory-7036cbef2b568fa0b6e458a9c8062571a65144e1...

--- a/libfuzzer/README.md
+++ b/libfuzzer/README.md
@@ -1,0 +1,94 @@
+# ubpf_fuzzer
+
+This is a libfuzzer based fuzzer.
+
+To build, run:
+```
+cmake \
+    -G Ninja \
+    -S . \
+    -B build \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DUBPF_ENABLE_LIBFUZZER=1 \
+    -DCMAKE_BUILD_TYPE=Debug
+
+cmake --build build
+```
+
+To run:
+Create folder for the corpus and artifacts for any crashes found, then run the fuzzer.
+
+```
+mkdir corpus
+mkdir artifacts
+build/bin/ubpf_fuzzer corpus -artifact_prefix=artifacts/
+```
+
+Optionally, add the "-jobs=100" to gather 100 crashes at a time.
+
+This will produce a lot of output that looks like:
+```
+#529745 REDUCE cov: 516 ft: 932 corp: 442/22Kb lim: 2875 exec/s: 264872 rss: 429Mb L: 50/188 MS: 3 CrossOver-ChangeBit-EraseBytes-
+#529814 REDUCE cov: 516 ft: 932 corp: 442/22Kb lim: 2875 exec/s: 264907 rss: 429Mb L: 45/188 MS: 4 ChangeBit-ShuffleBytes-PersAutoDict-EraseBytes- DE: "\005\000\000\000\000\000\000\000"-
+#530202 REDUCE cov: 516 ft: 932 corp: 442/22Kb lim: 2875 exec/s: 265101 rss: 429Mb L: 52/188 MS: 3 ChangeByte-ChangeASCIIInt-EraseBytes-
+#531224 REDUCE cov: 518 ft: 934 corp: 443/22Kb lim: 2875 exec/s: 265612 rss: 429Mb L: 73/188 MS: 2 CopyPart-PersAutoDict- DE: "\001\000\000\000"-
+#531750 REDUCE cov: 518 ft: 934 corp: 443/22Kb lim: 2875 exec/s: 265875 rss: 429Mb L: 45/188 MS: 1 EraseBytes-
+#532127 REDUCE cov: 519 ft: 935 corp: 444/22Kb lim: 2875 exec/s: 266063 rss: 429Mb L: 46/188 MS: 2 ChangeBinInt-ChangeByte-
+#532246 REDUCE cov: 519 ft: 935 corp: 444/22Kb lim: 2875 exec/s: 266123 rss: 429Mb L: 66/188 MS: 4 ChangeBit-CrossOver-ShuffleBytes-EraseBytes-
+#532357 NEW    cov: 520 ft: 936 corp: 445/22Kb lim: 2875 exec/s: 266178 rss: 429Mb L: 55/188 MS: 1 ChangeBinInt-
+#532404 REDUCE cov: 520 ft: 936 corp: 445/22Kb lim: 2875 exec/s: 266202 rss: 429Mb L: 57/188 MS: 2 ChangeBit-EraseBytes-
+#532486 REDUCE cov: 520 ft: 936 corp: 445/22Kb lim: 2875 exec/s: 266243 rss: 429Mb L: 44/188 MS: 2 EraseByte
+```
+
+Eventually it will probably crash and produce a message like:
+```
+=================================================================
+==376403==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x000000000000 bp 0x7ffca9d3cda0 sp 0x7ffca9d3cb98 T0)
+==376403==Hint: pc points to the zero page.
+==376403==The signal is caused by a READ memory access.
+==376403==Hint: address points to the zero page.
+    #0 0x0  (<unknown module>)
+    #1 0x50400001a48f  (<unknown module>)
+
+AddressSanitizer can not provide additional info.
+SUMMARY: AddressSanitizer: SEGV (<unknown module>)
+==376403==ABORTING
+MS: 1 ChangeByte-; base unit: cea14e5e2ecdc723b9beb640471a18b4ea529f75
+0x28,0x0,0x0,0x0,0xb4,0x50,0x10,0x6a,0x6a,0x4a,0x6a,0x2d,0x2e,0x1,0x0,0x0,0x0,0x0,0x0,0x0,0x4,0x21,0x0,0x0,0x0,0x0,0x95,0x95,0x26,0x21,0xfc,0xff,0xff,0xff,0x95,0x95,0x95,0x95,0x97,0xb7,0x97,0x97,0x0,0x8e,0x0,0x24,
+(\000\000\000\264P\020jjJj-.\001\000\000\000\000\000\000\004!\000\000\000\000\225\225&!\374\377\377\377\225\225\225\225\227\267\227\227\000\216\000$
+artifact_prefix='artifacts/'; Test unit written to artifacts/crash-7036cbef2b568fa0b6e458a9c8062571a65144e1
+Base64: KAAAALRQEGpqSmotLgEAAAAAAAAEIQAAAACVlSYh/P///5WVlZWXt5eXAI4AJA==
+```
+
+To triage the crash, the crash can be post processed using:
+```
+libfuzzer/split.sh artifacts/crash-7036cbef2b568fa0b6e458a9c8062571a65144e1
+
+
+Extracting program-7036cbef2b568fa0b6e458a9c8062571a65144e1...
+Extracting memory-7036cbef2b568fa0b6e458a9c8062571a65144e1...
+Disassembling program-7036cbef2b568fa0b6e458a9c8062571a65144e1...
+Program size: 40
+Memory size: 2
+Disassembled program:
+mov32 %r0, 0x2d6a4a6a
+jgt32 %r1, %r0, +0
+add32 %r1, 0x95950000
+jgt32 %r1, 0x9595ffff, -4
+exit
+Memory contents:
+00000000: 0024                                     .$
+```
+
+To repro the crash, you can run:
+```
+build/bin/ubpf_fuzzer artifacts/crash-7036cbef2b568fa0b6e458a9c8062571a65144e1
+```
+
+Or you can repro it using ubpf_test:
+```
+build/bin/ubpf-test --mem artifacts/memory-7036cbef2b568fa0b6e458a9c8062571a65144e1 artifacts/program-7036cbef2b568fa0b6e458a9c8062571a65144e1 --jit
+```
+

--- a/libfuzzer/libfuzz_harness.cc
+++ b/libfuzzer/libfuzz_harness.cc
@@ -10,7 +10,6 @@
 #include <string>
 #include <sstream>
 
-
 extern "C"
 {
 #include "ebpf.h"
@@ -42,6 +41,149 @@ int null_printf(FILE* stream, const char* format, ...)
     return 0;
 }
 
+typedef std::unique_ptr<ubpf_vm, decltype(&ubpf_destroy)> ubpf_vm_ptr;
+
+ubpf_vm_ptr create_ubpf_vm(const std::vector<uint8_t>& program_code)
+{
+    // Automatically free the VM when it goes out of scope.
+    std::unique_ptr<ubpf_vm, decltype(&ubpf_destroy)> vm(ubpf_create(), ubpf_destroy);
+
+    if (vm == nullptr) {
+        // Failed to create the VM.
+        // This is not interesting, as the fuzzer input is invalid.
+        // Do not add it to the corpus.
+        return vm;
+    }
+
+    ubpf_toggle_undefined_behavior_check(vm.get(), true);
+
+    char* error_message = nullptr;
+
+    ubpf_set_error_print(vm.get(), null_printf);
+
+    if (ubpf_load(vm.get(), program_code.data(), program_code.size(), &error_message) != 0) {
+        // The program failed to load, due to a validation error.
+        // This is not interesting, as the fuzzer input is invalid.
+        // Do not add it to the corpus.
+        free(error_message);
+        vm.reset();
+        return vm;
+    }
+
+    ubpf_toggle_bounds_check(vm.get(), true);
+
+    if (ubpf_register_external_dispatcher(vm.get(), test_helpers_dispatcher, test_helpers_validator) != 0) {
+        // Failed to register the external dispatcher.
+        // This is not interesting, as the fuzzer input is invalid.
+        // Do not add it to the corpus.
+        vm.reset();
+        return vm;
+    }
+
+    if (ubpf_set_instruction_limit(vm.get(), 10000, nullptr) != 0) {
+        // Failed to set the instruction limit.
+        // This is not interesting, as the fuzzer input is invalid.
+        // Do not add it to the corpus.
+        vm.reset();
+        return vm;
+    }
+
+    return vm;
+}
+
+bool call_ubpf_interpreter(const std::vector<uint8_t>& program_code, std::vector<uint8_t>& memory, std::vector<uint8_t>& ubpf_stack, uint64_t& interpreter_result)
+{
+    auto vm = create_ubpf_vm(program_code);
+
+    if (vm == nullptr) {
+        // VM creation failed.
+        return false;
+    }
+
+    // Execute the program using the input memory.
+    if (ubpf_exec_ex(vm.get(), memory.data(), memory.size(), &interpreter_result, ubpf_stack.data(), ubpf_stack.size()) != 0) {
+        // VM execution failed.
+        return false;
+    }
+
+    // VM execution succeeded.
+    return true;
+}
+
+bool call_ubpf_jit(const std::vector<uint8_t>& program_code, std::vector<uint8_t>& memory, std::vector<uint8_t>& ubpf_stack, uint64_t& jit_result)
+{
+    auto vm = create_ubpf_vm(program_code);
+
+    char* error_message = nullptr;
+
+    if (vm == nullptr) {
+        // VM creation failed.
+        return false;
+    }
+
+    auto fn = ubpf_compile_ex(vm.get(), &error_message, JitMode::ExtendedJitMode);
+
+    if (fn == nullptr) {
+        free(error_message);
+
+        // Compilation failed.
+        return false;
+    }
+
+    jit_result = fn(memory.data(), memory.size(), ubpf_stack.data(), ubpf_stack.size());
+
+    // Compilation succeeded.
+    return true;
+}
+
+bool call_linux_jit(const std::vector<uint8_t>& program_code, std::vector<uint8_t>& memory, std::vector<uint8_t> ubpf_stack, uint64_t& linux_jit_result);
+
+bool split_input(const uint8_t* data, std::size_t size, std::vector<uint8_t>& program, std::vector<uint8_t>& memory)
+{
+    if (size < 4)
+        return false;
+
+    uint32_t program_length = *reinterpret_cast<const uint32_t*>(data);
+    uint32_t memory_length = size - 4 - program_length;
+    const uint8_t* program_start = data + 4;
+    const uint8_t* memory_start = data + 4 + program_length;
+
+    if (program_length > size) {
+        // The program length is larger than the input size.
+        // This is not interesting, as the fuzzer input is invalid.
+        return false;
+    }
+
+    if (program_length == 0) {
+        // The program length is zero.
+        // This is not interesting, as the fuzzer input is invalid.
+        return false;
+    }
+
+    if (program_length + 4u > size) {
+        // The program length is larger than the input size.
+        // This is not interesting, as the fuzzer input is invalid.
+        return false;
+    }
+
+    if ((program_length % sizeof(ebpf_inst)) != 0) {
+        // The program length needs to be a multiple of sizeof(ebpf_inst_t).
+        // This is not interesting, as the fuzzer input is invalid.
+        return false;
+    }
+
+    // Copy any input memory into a writable buffer.
+    if (memory_length > 0) {
+        memory.resize(memory_length);
+        std::memcpy(memory.data(), memory_start, memory_length);
+    }
+
+    program.resize(program_length);
+    std::memcpy(program.data(), program_start, program_length);
+
+    return true;
+}
+
 /**
  * @brief Accept an input buffer and size.
  *
@@ -57,89 +199,41 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, std::size_t size)
     // program byte
     // test data
 
-    // Copy memory into a writable buffer.
+    std::vector<uint8_t> program;
     std::vector<uint8_t> memory;
+    std::vector<uint8_t> ubpf_stack(3*4096);
 
-    if (size < 4)
+    if (!split_input(data, size, program, memory)) {
+        // The input is invalid. Not interesting.
         return -1;
+    }
 
-    uint32_t program_length = *reinterpret_cast<const uint32_t*>(data);
-    uint32_t memory_length = size - 4 - program_length;
-    const uint8_t* program_start = data + 4;
-    const uint8_t* memory_start = data + 4 + program_length;
+    uint64_t interpreter_result = 0;
+    uint64_t jit_result = 0;
 
-    if (program_length > size) {
-        // The program length is larger than the input size.
+    if (!call_ubpf_interpreter(program, memory, ubpf_stack, interpreter_result)) {
+        // Failed to load or execute the program in the interpreter.
         // This is not interesting, as the fuzzer input is invalid.
-        // Do not add it to the corpus.
-        return -1;
-    }
-
-    if (program_length == 0) {
-        // The program length is zero.
-        // This is not interesting, as the fuzzer input is invalid.
-        // Do not add it to the corpus.
-        return -1;
-    }
-
-    if (program_length + 4u > size) {
-        // The program length is larger than the input size.
-        // This is not interesting, as the fuzzer input is invalid.
-        // Do not add it to the corpus.
-        return -1;
-    }
-
-    // Copy any input memory into a writable buffer.
-    if (memory_length > 0) {
-        memory.resize(memory_length);
-        std::memcpy(memory.data(), memory_start, memory_length);
-    }
-
-    // Automatically free the VM when it goes out of scope.
-    std::unique_ptr<ubpf_vm, decltype(&ubpf_destroy)> vm(ubpf_create(), ubpf_destroy);
-
-    if (vm == nullptr) {
-        // Failed to create the VM.
-        // This is not interesting, as the fuzzer input is invalid.
-        // Do not add it to the corpus.
-        return -1;
-    }
-
-    char* error_message = nullptr;
-
-    if (ubpf_load(vm.get(), program_start, program_length, &error_message) != 0) {
-        // The program failed to load, due to a validation error.
-        // This is not interesting, as the fuzzer input is invalid.
-        // Do not add it to the corpus.
-        free(error_message);
-        return -1;
-    }
-
-    ubpf_set_error_print(vm.get(), null_printf);
-
-    ubpf_toggle_bounds_check(vm.get(), true);
-
-    if (ubpf_register_external_dispatcher(vm.get(), test_helpers_dispatcher, test_helpers_validator) != 0) {
-        // Failed to register the external dispatcher.
-        // This is not interesting, as the fuzzer input is invalid.
-        // Do not add it to the corpus.
-        return -1;
-    }
-
-    if (ubpf_set_instruction_limit(vm.get(), 10000, nullptr) != 0) {
-        // Failed to set the instruction limit.
-        // This is not interesting, as the fuzzer input is invalid.
-        // Do not add it to the corpus.
-        return -1;
-    }
-
-    uint64_t result = 0;
-
-    // Execute the program using the input memory.
-    if (ubpf_exec(vm.get(), memory.data(), memory.size(), &result) != 0) {
-        // The program passed validation during load, but failed during execution.
-        // due to a runtime error. Add it to the corpus as it may be interesting.
         return 0;
+    }
+
+    if (!split_input(data, size, program, memory)) {
+        // The input is invalid. Not interesting.
+        return -1;
+    }
+
+    if (!call_ubpf_jit(program, memory, ubpf_stack, jit_result)) {
+        // Failed to load or execute the program in the JIT.
+        // This is not interesting, as the fuzzer input is invalid.
+        return 0;
+    }
+
+    // If interpreter_result is not equal to jit_result, raise a fatal signal
+    if (interpreter_result != jit_result) {
+        printf("%lx ubpf_stack\n", reinterpret_cast<uintptr_t>(ubpf_stack.data()) + ubpf_stack.size());
+        printf("interpreter_result: %lx\n", interpreter_result);
+        printf("jit_result: %lx\n", jit_result);
+        throw std::runtime_error("interpreter_result != jit_result");
     }
 
     // Program executed successfully.

--- a/libfuzzer/split.sh
+++ b/libfuzzer/split.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Split the file name into path and base name
+path=$(dirname $1)
+base=$(basename $1)
+
+# Get the first 4 bytes from the file (which is the length of the program)
+input="$(xxd -p -l 4 $1)"
+# Convert from little endian
+input="${input:6:2}${input:4:2}${input:2:2}${input:0:2}"
+
+# Convert input from hex string to value
+length=$((16#$input))
+
+# Extract the hash part from the file name
+hash=$(echo $base | cut -d'-' -f2-)
+
+# Copy the program to a file named program-$hash
+echo "Extracting program-$hash..."
+dd if=$1 of=$path/program-$hash bs=1 skip=4 count=$length 2> /dev/null
+
+echo "Extracting memory-$hash..."
+# Copy the rest to a file named memory-$hash
+dd if=$1 of=$path/memory-$hash bs=1 skip=$((4 + $length)) 2> /dev/null
+
+echo "Disassembling program-$hash..."
+# Unassembly program using bin/ubpf-disassembler
+bin/ubpf-disassembler $path/program-$hash > $path/program-$hash.asm
+
+echo "Program size: $(stat -c %s $path/program-$hash)"
+echo "Memory size: $(stat -c %s $path/memory-$hash)"
+
+echo "Disassembled program:"
+cat $path/program-$hash.asm
+
+echo "Memory contents:"
+xxd $path/memory-$hash

--- a/ubpf/disassembler.py
+++ b/ubpf/disassembler.py
@@ -128,6 +128,8 @@ def disassemble_one(data, offset):
         if opcode_name == "exit":
             return opcode_name
         elif opcode_name == "call":
+            if src_reg == 1:
+                opcode_name += " local"
             return "%s %s" % (opcode_name, I(imm))
         elif opcode_name == "ja":
             return "%s %s" % (opcode_name, O(off))
@@ -143,6 +145,8 @@ def disassemble_one(data, offset):
         if opcode_name == "exit":
             return opcode_name
         elif opcode_name == "call":
+            if src_reg == 1:
+                opcode_name += " local"
             return "%s %s" % (opcode_name, I(imm))
         elif opcode_name == "ja":
             return "%s %s" % (opcode_name, O(off))

--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -544,6 +544,17 @@ extern "C"
     int
     ubpf_set_instruction_limit(struct ubpf_vm* vm, uint32_t limit, uint32_t* previous_limit);
 
+    /**
+     * @brief Enable or disable undefined behavior checks. Undefined behavior includes
+     * reading from uninitialized memory or using uninitialized registers.
+     *
+     * @param[in] vm VM to enable or disable undefined behavior checks on.
+     * @param[in] enable Enable undefined behavior checks if true, disable if false.
+     * @return true if undefined behavior checks were previously enabled.
+     * @return false if undefined behavior checks were previously disabled.
+     */
+    bool
+    ubpf_toggle_undefined_behavior_check(struct ubpf_vm* vm, bool enable);
 #ifdef __cplusplus
 }
 #endif

--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -546,7 +546,8 @@ extern "C"
 
     /**
      * @brief Enable or disable undefined behavior checks. Undefined behavior includes
-     * reading from uninitialized memory or using uninitialized registers.
+     * reading from uninitialized memory or using uninitialized registers. Default is disabled to
+     * preserve performance and compatibility with existing eBPF programs.
      *
      * @param[in] vm VM to enable or disable undefined behavior checks on.
      * @param[in] enable Enable undefined behavior checks if true, disable if false.

--- a/vm/ubpf_int.h
+++ b/vm/ubpf_int.h
@@ -74,6 +74,7 @@ struct ubpf_vm
     external_function_validate_t dispatcher_validate;
 
     bool bounds_check_enabled;
+    bool undefined_behavior_check_enabled;
     int (*error_printf)(FILE* stream, const char* format, ...);
     struct ubpf_jit_result (*jit_translate)(struct ubpf_vm* vm, uint8_t* buffer, size_t* size, enum JitMode jit_mode);
     bool (*jit_update_dispatcher)(

--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -56,6 +56,14 @@ ubpf_toggle_bounds_check(struct ubpf_vm* vm, bool enable)
     return old;
 }
 
+bool
+ubpf_toggle_undefined_behavior_check(struct ubpf_vm* vm, bool enable)
+{
+    bool old = vm->undefined_behavior_check_enabled;
+    vm->undefined_behavior_check_enabled = enable;
+    return old;
+}
+
 void
 ubpf_set_error_print(struct ubpf_vm* vm, int (*error_printf)(FILE* stream, const char* format, ...))
 {
@@ -105,6 +113,7 @@ ubpf_create(void)
     }
 
     vm->bounds_check_enabled = true;
+    vm->undefined_behavior_check_enabled = false;
     vm->error_printf = fprintf;
 
 #if defined(__x86_64__) || defined(_M_X64)
@@ -373,6 +382,220 @@ ubpf_mem_store(uint64_t address, uint64_t value, size_t size)
     }
 }
 
+/**
+ * @brief Mark the bits in the shadow stack corresponding to the address if it is within the stack bounds.
+ *
+ * @param[in] stack The base address of the stack.
+ * @param[in] shadow_stack The base address of the shadow stack.
+ * @param[in] address The address being written to.
+ * @param[in] size The number of bytes being written.
+ */
+static inline void
+ubpf_mark_shadow_stack(
+    const struct ubpf_vm* vm, uint8_t* stack, uint64_t stack_length, uint8_t* shadow_stack, void* address, size_t size)
+{
+    if (!vm->undefined_behavior_check_enabled) {
+        return;
+    }
+
+    uintptr_t access_start = (uintptr_t)address;
+    uintptr_t access_end = access_start + size;
+    uintptr_t stack_start = (uintptr_t)stack;
+    uintptr_t stack_end = stack_start + stack_length;
+
+    if (access_start > access_end) {
+        // Overflow
+        return;
+    }
+
+    if (access_start >= stack_start && access_end <= stack_end) {
+        // Shadow stack is an bit array, where each bit corresponds to 1 byte in the stack.
+        // If the bit is set, the memory is initialized.
+        size_t offset = access_start - stack_start;
+        for (size_t test_bit = offset; test_bit < offset + size; test_bit++) {
+            // Convert test_bit into offset + mask to test against the shadow stack.
+            size_t bit_offset = test_bit / 8;
+            size_t bit_mask = 1 << (test_bit % 8);
+            shadow_stack[bit_offset] |= bit_mask;
+        }
+    }
+}
+
+/**
+ * @brief Check if the address is within the stack bounds and the shadow stack is marked for the address.
+ *
+ * @param[in] stack The base address of the stack.
+ * @param[in] shadow_stack The base address of the shadow stack.
+ * @param[in] address The address being read from.
+ * @param[in] size The number of bytes being read.
+ * @return true - The read is from initialized memory or is not within the stack bounds.
+ * @return false - The read is from uninitialized memory within the stack bounds.
+ */
+static inline bool
+ubpf_check_shadow_stack(
+    const struct ubpf_vm* vm, uint8_t* stack, uint64_t stack_length, uint8_t* shadow_stack, void* address, size_t size)
+{
+    if (!vm->undefined_behavior_check_enabled) {
+        return true;
+    }
+
+    uintptr_t access_start = (uintptr_t)address;
+    uintptr_t access_end = access_start + size;
+    uintptr_t stack_start = (uintptr_t)stack;
+    uintptr_t stack_end = stack_start + stack_length;
+
+    if (access_start > access_end) {
+        // Overflow
+        return true;
+    }
+
+    if (access_start >= stack_start && access_end <= stack_end) {
+        // Shadow stack is an bit array, where each bit corresponds to 1 byte in the stack.
+        // If the bit is set, the memory is initialized.
+        size_t offset = access_start - stack_start;
+        for (size_t test_bit = offset; test_bit < offset + size; test_bit++) {
+            // Convert test_bit into offset + mask to test against the shadow stack.
+            size_t bit_offset = test_bit / 8;
+            size_t bit_mask = 1 << (test_bit % 8);
+            if ((shadow_stack[bit_offset] & bit_mask) == 0) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+/**
+ * @brief Check if the registers being accessed by this instruction are initialized and mark the destination register as
+ * initialized if it is.
+ *
+ * @param[in] vm The VM instance.
+ * @param[in,out] shadow_registers Storage for the shadow register state.
+ * @param[in] inst The instruction being executed.
+ * @return true - The registers are initialized.
+ * @return false - The registers are not initialized - an error message has been printed.
+ */
+static inline bool
+ubpf_validate_shadow_register(const struct ubpf_vm* vm, uint16_t* shadow_registers, struct ebpf_inst inst)
+{
+    if (!vm->undefined_behavior_check_enabled) {
+        return true;
+    }
+
+    bool src_register_required = false;
+    bool dst_register_required = false;
+    bool dst_register_initialized = false;
+
+    switch (inst.opcode & EBPF_CLS_MASK) {
+    // Load instructions initialize the destination register.
+    case EBPF_CLS_LD:
+        dst_register_initialized = true;
+        break;
+    // Load indirect instructions initialize the destination register and require the source register to be initialized.
+    case EBPF_CLS_LDX:
+        src_register_required = true;
+        dst_register_initialized = true;
+        break;
+    // Store instructions require the destination register to be initialized.
+    case EBPF_CLS_ST:
+        dst_register_required = true;
+        break;
+    // Store indirect instructions require both the source and destination registers to be initialized.
+    case EBPF_CLS_STX:
+        dst_register_required = true;
+        src_register_required = true;
+        break;
+    case EBPF_CLS_ALU:
+    case EBPF_CLS_ALU64:
+        // Source register is required if the EBPF_SRC_REG bit is set.
+        src_register_required = inst.opcode & EBPF_SRC_REG;
+        dst_register_initialized = true;
+        switch (inst.opcode & EBPF_ALU_OP_MASK) {
+        case 0x00: // EBPF_OP_ADD
+        case 0x10: // EBPF_OP_SUB
+        case 0x20: // EBPF_OP_MUL
+        case 0x30: // EBPF_OP_DIV
+        case 0x40: // EBPF_OP_OR
+        case 0x50: // EBPF_OP_AND
+        case 0x60: // EBPF_OP_LSH
+        case 0x70: // EBPF_OP_RSH
+        case 0x80: // EBPF_OP_NEG
+        case 0x90: // EBPF_OP_MOD
+        case 0xa0: // EBPF_OP_XOR
+        case 0xc0: // EBPF_OP_ARSH
+        case 0xd0: // EBPF_OP_LE
+            dst_register_required = true;
+            break;
+        case 0xb0: // EBPF_OP_MOV
+            // Destination register is initialized.
+            break;
+        }
+        break;
+    case EBPF_CLS_JMP:
+    case EBPF_CLS_JMP32:
+        // Source register is required if the EBPF_SRC_REG bit is set.
+        src_register_required = inst.opcode & EBPF_SRC_REG;
+        switch (inst.opcode & EBPF_JMP_OP_MASK) {
+        case EBPF_MODE_JA:
+        case EBPF_MODE_CALL:
+        case EBPF_MODE_EXIT:
+            src_register_required = false;
+            break;
+        case EBPF_MODE_JEQ:
+        case EBPF_MODE_JGT:
+        case EBPF_MODE_JGE:
+        case EBPF_MODE_JSET:
+        case EBPF_MODE_JNE:
+        case EBPF_MODE_JSGT:
+        case EBPF_MODE_JSGE:
+        case EBPF_MODE_JLT:
+        case EBPF_MODE_JLE:
+        case EBPF_MODE_JSLT:
+        case EBPF_MODE_JSLE:
+            dst_register_required = true;
+            break;
+        }
+        break;
+    }
+
+    if (src_register_required && !(*shadow_registers & (1 << inst.src))) {
+        vm->error_printf(stderr, "Error: Source register r%d is not initialized.\n", inst.src);
+        return false;
+    }
+
+    if (dst_register_required && !(*shadow_registers & (1 << inst.dst))) {
+        vm->error_printf(stderr, "Error: Destination register r%d is not initialized.\n", inst.dst);
+        return false;
+    }
+
+    if (dst_register_initialized) {
+        *shadow_registers |= 1 << inst.dst;
+    }
+
+    if (inst.opcode == EBPF_OP_CALL) {
+        if (inst.src == 0) {
+            // Mark the return address register as initialized.
+            *shadow_registers |= 1 << 0;
+
+            // Mark r1-r5 as uninitialized.
+            *shadow_registers &= ~0x3e;
+        } else if (inst.src == 1) {
+            // Do nothing, register state will be handled by the callee on return.
+        }
+    }
+
+    if (inst.opcode == EBPF_OP_EXIT) {
+        if (!(*shadow_registers & (1 << 0))) {
+            vm->error_printf(stderr, "Error: Return address register r0 is not initialized.\n");
+            return false;
+        }
+        // Mark r1-r5 as uninitialized.
+        *shadow_registers &= ~0x3e;
+    }
+
+    return true;
+}
+
 int
 ubpf_exec_ex(
     const struct ubpf_vm* vm,
@@ -389,6 +612,9 @@ ubpf_exec_ex(
     uint64_t stack_frame_index = 0;
     int return_value = -1;
     void* external_dispatcher_cookie = mem;
+    void* shadow_stack = NULL;
+
+    struct ebpf_inst previous_inst = {.opcode = 0};
 
     if (!insts) {
         /* Code must be loaded before we can execute */
@@ -399,6 +625,14 @@ ubpf_exec_ex(
         0,
     };
 
+    if (vm->undefined_behavior_check_enabled) {
+        shadow_stack = calloc(stack_length / 8, 1);
+        if (!shadow_stack) {
+            return_value = -1;
+            goto cleanup;
+        }
+    }
+
 #ifdef DEBUG
     if (vm->regs)
         reg = vm->regs;
@@ -407,10 +641,14 @@ ubpf_exec_ex(
 #else
     reg = _reg;
 #endif
+    uint16_t shadow_registers = 0; // Bit mask of registers that have been written to.
 
     reg[1] = (uintptr_t)mem;
     reg[2] = (uint64_t)mem_len;
     reg[10] = (uintptr_t)stack_start + stack_length;
+
+    // Mark r1, r2, r10 as initialized.
+    shadow_registers |= (1 << 1) | (1 << 2) | (1 << 10);
 
     int instruction_limit = vm->instruction_limit;
 
@@ -426,10 +664,25 @@ ubpf_exec_ex(
         }
 
         if ((pc == 0 || vm->int_funcs[pc]) && stack_frame_index < UBPF_MAX_CALL_DEPTH) {
+            // If this is neither the first instruction nor a local function call, then the behavior is undefined.
+            if (previous_inst.opcode != 0 && !(previous_inst.opcode == EBPF_OP_CALL && previous_inst.src == 1)) {
+                // Previous instruction wasn't a call to this instruction, so behavior is undefined.
+                if (vm->undefined_behavior_check_enabled) {
+                    vm->error_printf(
+                        stderr, "Error: Call to local function at pc %d is not from a call instruction.\n", pc);
+                    return_value = -1;
+                    goto cleanup;
+                }
+            }
             stack_frames[stack_frame_index].stack_usage = ubpf_stack_usage_for_local_func(vm, pc);
         }
 
         struct ebpf_inst inst = ubpf_fetch_instruction(vm, pc++);
+
+        if (!ubpf_validate_shadow_register(vm, &shadow_registers, inst)) {
+            return_value = -1;
+            goto cleanup;
+        }
 
         switch (inst.opcode) {
         case EBPF_OP_ADD_IMM:
@@ -630,37 +883,43 @@ ubpf_exec_ex(
              *
              * Needed since we don't have a verifier yet.
              */
-#define BOUNDS_CHECK_LOAD(size)                     \
-    do {                                            \
-        if (!bounds_check(                          \
-                vm,                                 \
-                (char*)reg[inst.src] + inst.offset, \
-                size,                               \
-                "load",                             \
-                cur_pc,                             \
-                mem,                                \
-                mem_len,                            \
-                stack_start,                        \
-                stack_length)) {                    \
-            return_value = -1;                      \
-            goto cleanup;                           \
-        }                                           \
+#define BOUNDS_CHECK_LOAD(size)                                                                           \
+    do {                                                                                                  \
+        if (!ubpf_check_shadow_stack(                                                                     \
+                vm, stack_start, stack_length, shadow_stack, (char*)reg[inst.src] + inst.offset, size)) { \
+            return_value = -1;                                                                            \
+            goto cleanup;                                                                                 \
+        }                                                                                                 \
+        if (!bounds_check(                                                                                \
+                vm,                                                                                       \
+                (char*)reg[inst.src] + inst.offset,                                                       \
+                size,                                                                                     \
+                "load",                                                                                   \
+                cur_pc,                                                                                   \
+                mem,                                                                                      \
+                mem_len,                                                                                  \
+                stack_start,                                                                              \
+                stack_length)) {                                                                          \
+            return_value = -1;                                                                            \
+            goto cleanup;                                                                                 \
+        }                                                                                                 \
     } while (0)
-#define BOUNDS_CHECK_STORE(size)                    \
-    do {                                            \
-        if (!bounds_check(                          \
-                vm,                                 \
-                (char*)reg[inst.dst] + inst.offset, \
-                size,                               \
-                "store",                            \
-                cur_pc,                             \
-                mem,                                \
-                mem_len,                            \
-                stack_start,                        \
-                stack_length)) {                    \
-            return_value = -1;                      \
-            goto cleanup;                           \
-        }                                           \
+#define BOUNDS_CHECK_STORE(size)                                                                                       \
+    do {                                                                                                               \
+        if (!bounds_check(                                                                                             \
+                vm,                                                                                                    \
+                (char*)reg[inst.dst] + inst.offset,                                                                    \
+                size,                                                                                                  \
+                "store",                                                                                               \
+                cur_pc,                                                                                                \
+                mem,                                                                                                   \
+                mem_len,                                                                                               \
+                stack_start,                                                                                           \
+                stack_length)) {                                                                                       \
+            return_value = -1;                                                                                         \
+            goto cleanup;                                                                                              \
+        }                                                                                                              \
+        ubpf_mark_shadow_stack(vm, stack_start, stack_length, shadow_stack, (char*)reg[inst.dst] + inst.offset, size); \
     } while (0)
 
         case EBPF_OP_LDXW:
@@ -1002,16 +1261,25 @@ ubpf_exec_ex(
             // Because we have already validated, we can assume that the type code is
             // valid.
             break;
+        default:
+            vm->error_printf(stderr, "Error: unknown opcode %d at PC %d\n", inst.opcode, cur_pc);
+            return_value = -1;
+            goto cleanup;
         }
         if (((inst.opcode & EBPF_CLS_MASK) == EBPF_CLS_ALU) && (inst.opcode & EBPF_ALU_OP_MASK) != 0xd0) {
             reg[inst.dst] &= UINT32_MAX;
         }
+        // Save the previous instruction for detecting falling through to the start of another function.
+        previous_inst = inst;
     }
 
 cleanup:
 #if defined(NTDDI_VERSION) && defined(WINNT)
     free(stack_frames);
 #endif
+    if (shadow_stack) {
+        free(shadow_stack);
+    }
     return return_value;
 }
 
@@ -1358,6 +1626,7 @@ ubpf_get_registers(const struct ubpf_vm* vm)
 {
     return vm->regs;
 }
+
 #else
 void
 ubpf_set_registers(struct ubpf_vm* vm, uint64_t* regs)


### PR DESCRIPTION
This pull request includes changes to improve the `ubpf` library. The most important changes include adding a new libfuzzer based fuzzer, modifying the `LLVMFuzzerTestOneInput` function to compare the results of the interpreter and JIT compiler, adding a bash script to split the fuzzer input into a program and memory, and adding bounds checking for memory accesses.

Improvements to fuzzing:

* [`libfuzzer/README.md`](diffhunk://#diff-ec67aab0b02e9ef86ef2b779f818f9e937c48440fe4b11fab3eccfc025ca40e7R1-R94): Added instructions for building and running a new libfuzzer based fuzzer.
* [`libfuzzer/libfuzz_harness.cc`](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524R92-R98): Modified the `LLVMFuzzerTestOneInput` function to compare the results of the interpreter and JIT compiler, and to ensure the program length is a multiple of `sizeof(ebpf_inst)`. [[1]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524R92-R98) [[2]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524L136-R172)
* [`libfuzzer/split.sh`](diffhunk://#diff-6218b71516f0e09a7de0f20c42c91529363d44ff4d70376b5cca3d197d52f3f0R1-R37): Added a bash script to split the fuzzer input into a program and memory, and to disassemble the program.

Improvements to disassembler:

* [`ubpf/disassembler.py`](diffhunk://#diff-d90f98ac0def87d3c80ca75f0f13e5831bb21e5b0ab9752962d062e97f79057bR131-R132): Modified the `disassemble_one` function to append " local" to the opcode name if the source register is 1. [[1]](diffhunk://#diff-d90f98ac0def87d3c80ca75f0f13e5831bb21e5b0ab9752962d062e97f79057bR131-R132) [[2]](diffhunk://#diff-d90f98ac0def87d3c80ca75f0f13e5831bb21e5b0ab9752962d062e97f79057bR148-R149)

Improvements to JIT compiler:

* [`vm/ubpf_jit_x86_64.c`](diffhunk://#diff-faaefdbfc142f09bf9f246a6c93375c692c02451e4f2a58073daa4c350d2c8aeR772-R777): Added code to truncate the target register to 32 bits for ALU32 instructions.
* [`vm/ubpf_jit_x86_64.h`](diffhunk://#diff-85ce3ca7e3c857eb5fafb56894b54ae7fa724c18416500c94be4345ca49a5730R228-R233): Added the `emit_truncate_u32` function to emit instructions to truncate a register to 32 bits.

Improvements to VM:

* [`vm/ubpf_vm.c`](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fR376-R578): Added bounds checking for memory accesses, and added checks to ensure registers are initialized before they are read. Also fixed a bug in the `EBPF_OP_JEQ32_REG` instruction. [[1]](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fR376-R578) [[2]](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fR595) [[3]](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fR622-R630) [[4]](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fR650-R654) [[5]](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fR856-R860) [[6]](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fR890) [[7]](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fL740-R967) [[8]](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fR1233-R1244) [[9]](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fR1591)

Resolves: #480