### PR TITLE
Use flag instead of imm value to determine if this is register to register operation

### DIFF
--- a/vm/ubpf_jit_x86_64.c
+++ b/vm/ubpf_jit_x86_64.c
@@ -819,7 +819,7 @@ muldivmod(struct jit_state* state, uint8_t opcode, int src, int dst, int32_t imm
     }
 
     // Load the divisor into RCX.
-    if (imm) {
+    if (!reg) {
         emit_load_imm(state, RCX, imm);
     } else {
         emit_mov(state, src, RCX);


### PR DESCRIPTION
This pull request contains a modification to the `muldivmod` function in the `vm/ubpf_jit_x86_64.c` file. The change is in the condition for loading the divisor into the RCX register. Previously, the divisor was loaded if `imm` was true. The updated code now loads the divisor if `reg` is not true. This change might affect how the divisor is loaded into the RCX register depending on the value of `reg`.