### PR TITLE
Add JMP32 class to disassembler

### DIFF
--- a/ubpf/disassembler.py
+++ b/ubpf/disassembler.py
@@ -13,6 +13,7 @@ CLASSES = {
     3: "stx",
     4: "alu",
     5: "jmp",
+    6: "jmp32",
     7: "alu64",
 }
 
@@ -71,6 +72,7 @@ BPF_CLASS_ST = 2
 BPF_CLASS_STX = 3
 BPF_CLASS_ALU = 4
 BPF_CLASS_JMP = 5
+BPF_CLASS_JMP32 = 6
 BPF_CLASS_ALU64 = 7
 
 BPF_ALU_NEG = 8
@@ -122,6 +124,21 @@ def disassemble_one(data, offset):
         source = (code >> 3) & 1
         opcode = (code >> 4) & 0xf
         opcode_name = JMP_OPCODES.get(opcode)
+
+        if opcode_name == "exit":
+            return opcode_name
+        elif opcode_name == "call":
+            return "%s %s" % (opcode_name, I(imm))
+        elif opcode_name == "ja":
+            return "%s %s" % (opcode_name, O(off))
+        elif source == 0:
+            return "%s %s, %s, %s" % (opcode_name, R(dst_reg), I(imm), O(off))
+        else:
+            return "%s %s, %s, %s" % (opcode_name, R(dst_reg), R(src_reg), O(off))
+    elif cls == BPF_CLASS_JMP32:
+        source = (code >> 3) & 1
+        opcode = (code >> 4) & 0xf
+        opcode_name = JMP_OPCODES.get(opcode) + "32"
 
         if opcode_name == "exit":
             return opcode_name


### PR DESCRIPTION
This pull request primarily focuses on enhancing the `ubpf/disassembler.py` script with support for 32-bit jumps in the eBPF bytecode disassembly process. The changes include the addition of a new opcode and class for 32-bit jumps, and an update to the `disassemble_one` function to handle the new opcode and class.

Here are the key changes:

* [`ubpf/disassembler.py`](diffhunk://#diff-d90f98ac0def87d3c80ca75f0f13e5831bb21e5b0ab9752962d062e97f79057bR16): Added a new opcode `jmp32` to the `JMP_OPCODES` dictionary, which maps opcodes to their string names.
* [`ubpf/disassembler.py`](diffhunk://#diff-d90f98ac0def87d3c80ca75f0f13e5831bb21e5b0ab9752962d062e97f79057bR75): Introduced a new class `BPF_CLASS_JMP32` with a value of 6, representing the class for 32-bit jumps.
* [`ubpf/disassembler.py`](diffhunk://#diff-d90f98ac0def87d3c80ca75f0f13e5831bb21e5b0ab9752962d062e97f79057bR128-R142): Updated the `disassemble_one` function to handle the new `BPF_CLASS_JMP32` class. It now checks if the class is `BPF_CLASS_JMP32` and if so, it retrieves the opcode name and appends "32" to it, indicating a 32-bit jump. The function then proceeds to disassemble the bytecode instruction accordingly.