### PR TITLE
Truncate all ALU32 except for byte swap

### DIFF
--- a/vm/ubpf_jit_x86_64.c
+++ b/vm/ubpf_jit_x86_64.c
@@ -723,6 +723,12 @@ translate(struct ubpf_vm* vm, struct jit_state* state, char** errmsg)
             state->jit_status = UnknownInstruction;
             *errmsg = ubpf_error("Unknown instruction at PC %d: opcode %02x", i, inst.opcode);
         }
+
+        // If this is a ALU32 instruction, truncate the target register to 32 bits.
+        if (((inst.opcode & EBPF_CLS_MASK) == EBPF_CLS_ALU) &&
+            (inst.opcode & EBPF_ALU_OP_MASK) != 0xd0) {
+            emit_truncate_u32(state, dst);
+        }
     }
 
     if (state->jit_status != NoError) {

--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -971,6 +971,10 @@ ubpf_exec(const struct ubpf_vm* vm, void* mem, size_t mem_len, uint64_t* bpf_ret
             // valid.
             break;
         }
+        if (((inst.opcode & EBPF_CLS_MASK) == EBPF_CLS_ALU) &&
+            (inst.opcode & EBPF_ALU_OP_MASK) != 0xd0) {
+            reg[inst.dst] &= UINT32_MAX;
+        }
     }
 
 cleanup:


### PR DESCRIPTION
Resolves: #452

This pull request primarily focuses on modifications to the `ubpf_vm` package, specifically the `translate` function in `ubpf_jit_x86_64.c` and the `ubpf_exec` function in `ubpf_vm.c`. The changes are centered around the handling of ALU32 instructions. In both functions, additional code has been added to check if an instruction is an ALU32 instruction and perform certain operations if it is.

Here are the key changes:

* [`vm/ubpf_jit_x86_64.c`](diffhunk://#diff-faaefdbfc142f09bf9f246a6c93375c692c02451e4f2a58073daa4c350d2c8aeR726-R731): In the `translate` function, a check has been added to identify if an instruction is an ALU32 instruction. If it is, the target register is truncated to 32 bits using the `emit_truncate_u32` function.

* [`vm/ubpf_vm.c`](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fR974-R977): Similar to the `translate` function, the `ubpf_exec` function now checks if an instruction is an ALU32 instruction. If it is, the destination register (`inst.dst`) is bitwise ANDed with `UINT32_MAX` to ensure it only retains the lower 32 bits of the value.