### PR TITLE
Move fuzzing to it's own workflow

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -4,38 +4,29 @@
 name: Fuzzing
 
 permissions:
-  contents: read
+  contents: write
 
 on:
-  workflow_call:
-    inputs:
-      arch:
-        description: 'Architecture'
-        required: true
-        type: string
+  schedule: # Run every day at 21:00 UTC
+    - cron: '00 21 * * *'
+  workflow_dispatch: # Run manually
 
-      platform:
-        required: true
-        type: string
+env:
+    platform: ubuntu-latest
+    arch: x86_64
 
 jobs:
   build:
-    runs-on: ${{ inputs.platform }}
+    runs-on: ${{ env.platform }}
 
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 
-    - name: Initialize CodeQL
-      if: inputs.build_codeql == true
-      uses: github/codeql-action/init@d39d31e687223d841ef683f52467bd88e9b21c14
-      with:
-        languages: 'cpp'
-
     - name: Generate the cache key
       id: cache_key
-      run: echo "VALUE=platform-${{ inputs.platform }}_arch=${{ inputs.arch }}_type=fuzzing" >> $GITHUB_OUTPUT
+      run: echo "VALUE=platform-${{ env.platform }}_arch=${{ env.arch }}_type=fuzzing" >> $GITHUB_OUTPUT
 
     - name: Update the cache (ccache)
       uses: actions/cache@v4.0.2
@@ -49,7 +40,7 @@ jobs:
           ccache
 
     - name: Install system dependencies (Linux)
-      if: inputs.platform == 'ubuntu-latest'
+      if: env.platform == 'ubuntu-latest'
       run: |
         sudo apt-get update
 
@@ -63,12 +54,12 @@ jobs:
           libboost-filesystem-dev \
           libelf-dev
 
-        if [[ "${{ inputs.scan_build }}" == "true" ]] ; then
+        if [[ "${{ env.scan_build }}" == "true" ]] ; then
           sudo apt-get install -y \
             clang-tools
         fi
 
-        if [[ "${{ inputs.arch }}" == "arm64" ]] ; then
+        if [[ "${{ env.arch }}" == "arm64" ]] ; then
           sudo apt install -y \
             g++-aarch64-linux-gnu \
             gcc-aarch64-linux-gnu \
@@ -76,12 +67,12 @@ jobs:
         fi
 
     - name: Build/install libbpf From Source
-      if: inputs.platform == 'ubuntu-latest'
+      if: env.platform == 'ubuntu-latest'
       run: ./.github/scripts/build-libbpf.sh
       shell: bash
 
     - name: Install system dependencies (macOS)
-      if: inputs.platform == 'macos-11'
+      if: env.platform == 'macos-11'
       run: |
         brew install \
           cmake \
@@ -98,7 +89,7 @@ jobs:
           -G Ninja \
           -S . \
           -B build \
-          -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} \
+          -DCMAKE_BUILD_TYPE=${{ env.build_type }} \
           -DCMAKE_C_COMPILER=clang \
           -DCMAKE_CXX_COMPILER=clang++ \
           -DUBPF_ENABLE_LIBFUZZER=1 \
@@ -109,7 +100,7 @@ jobs:
       run: |
         export CCACHE_DIR="$(pwd)/ccache"
 
-        if [[ "${{ inputs.scan_build }}" == "true" ]] ; then
+        if [[ "${{ env.scan_build }}" == "true" ]] ; then
           command_prefix="scan-build -o scan_build_report"
         fi
 
@@ -152,7 +143,7 @@ jobs:
         git config --global user.email 'ubpf@users.noreply.github.com'
         git config --global user.name 'Github Action'
         git commit -sm "Update fuzzing corpus"
-        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/iovisor/ubpf.git
+        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{github.repository}}.git
         git push
 
     - name: Upload artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -310,14 +310,6 @@ jobs:
       enable_sanitizers: true
       disable_retpolines: true
 
-  # Run fuzzing on scheduled task only.
-  linux_fuzzing:
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/fuzzing.yml
-    with:
-      arch: x86_64
-      platform: ubuntu-latest
-
   # Disabled until https://github.com/iovisor/ubpf/issues/155 is resolved.
   # linux_debug_arm64_sanitizers:
   #   uses: ./.github/workflows/posix.yml


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow files `.github/workflows/fuzzing.yml` and `.github/workflows/main.yml`. The changes mainly involve the modification of the fuzzing workflow, including the change of permissions, scheduling, and the use of environment variables instead of inputs. The most important changes are:

1. `.github/workflows/fuzzing.yml`: Permissions for the fuzzing workflow have been changed from read to write.
2. `.github/workflows/fuzzing.yml`: The trigger for the fuzzing workflow has been changed from a workflow call to a daily schedule at 21:00 UTC and a manual dispatch.
3. `.github/workflows/fuzzing.yml`: The use of inputs has been replaced with environment variables. This change affects the platform and architecture parameters used in the workflow, as well as several conditionals and commands within the workflow. [[1]](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL7-R29) [[2]](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL52-R43) [[3]](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL66-R75) [[4]](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL101-R92) [[5]](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL112-R103)
4. `.github/workflows/fuzzing.yml`: The repository URL used when pushing updates to the fuzzing corpus has been changed to use the `github.repository` context instead of a hardcoded repository URL.
5. `.github/workflows/main.yml`: The reference to the fuzzing workflow has been removed.

These changes seem to aim at making the fuzzing workflow more autonomous and flexible, by allowing it to run on a schedule or manually, and by using environment variables instead of inputs.