### PR TITLE
Create matrix for fuzzing

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -11,14 +11,16 @@ on:
     - cron: '00 21 * * *'
   workflow_dispatch: # Run manually
 
-
 jobs:
   build:
-    env:
-        platform: ubuntu-latest
-        arch: x86_64
+    strategy:
+      matrix:
+        platform:
+          - ubuntu-latest
+        arch:
+          - x86_64
 
-    runs-on: ${{ env.platform }}
+    runs-on: ${{ matrix.platform }}
 
     steps:
     - uses: actions/checkout@v4
@@ -27,7 +29,7 @@ jobs:
 
     - name: Generate the cache key
       id: cache_key
-      run: echo "VALUE=platform-${{ env.platform }}_arch=${{ env.arch }}_type=fuzzing" >> $GITHUB_OUTPUT
+      run: echo "VALUE=platform-${{ matrix.platform }}_arch=${{ matrix.arch }}_type=fuzzing" >> $GITHUB_OUTPUT
 
     - name: Update the cache (ccache)
       uses: actions/cache@v4.0.2
@@ -41,7 +43,7 @@ jobs:
           ccache
 
     - name: Install system dependencies (Linux)
-      if: env.platform == 'ubuntu-latest'
+      if: matrix.platform == 'ubuntu-latest'
       run: |
         sudo apt-get update
 
@@ -55,12 +57,7 @@ jobs:
           libboost-filesystem-dev \
           libelf-dev
 
-        if [[ "${{ env.scan_build }}" == "true" ]] ; then
-          sudo apt-get install -y \
-            clang-tools
-        fi
-
-        if [[ "${{ env.arch }}" == "arm64" ]] ; then
+        if [[ "${{ matrix.arch }}" == "arm64" ]] ; then
           sudo apt install -y \
             g++-aarch64-linux-gnu \
             gcc-aarch64-linux-gnu \
@@ -68,12 +65,12 @@ jobs:
         fi
 
     - name: Build/install libbpf From Source
-      if: env.platform == 'ubuntu-latest'
+      if: matrix.platform == 'ubuntu-latest'
       run: ./.github/scripts/build-libbpf.sh
       shell: bash
 
     - name: Install system dependencies (macOS)
-      if: env.platform == 'macos-11'
+      if: matrix.platform == 'macos-11'
       run: |
         brew install \
           cmake \
@@ -90,7 +87,7 @@ jobs:
           -G Ninja \
           -S . \
           -B build \
-          -DCMAKE_BUILD_TYPE=${{ env.build_type }} \
+          -DCMAKE_BUILD_TYPE=Debug \
           -DCMAKE_C_COMPILER=clang \
           -DCMAKE_CXX_COMPILER=clang++ \
           -DUBPF_ENABLE_LIBFUZZER=1 \
@@ -100,10 +97,6 @@ jobs:
     - name: Build uBPF
       run: |
         export CCACHE_DIR="$(pwd)/ccache"
-
-        if [[ "${{ env.scan_build }}" == "true" ]] ; then
-          command_prefix="scan-build -o scan_build_report"
-        fi
 
         ${command_prefix} cmake \
           --build build


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/fuzzing.yml` file, which is part of the GitHub Actions workflow. The changes primarily focus on replacing the use of environment variables with a matrix strategy for the job configurations. This allows for more flexibility in defining and managing the job configurations.

Here are the most important changes:

* Replaced the `env:` block with a `strategy:` block that uses a matrix to define `platform` and `arch` parameters. This change allows for more flexibility in defining and managing the job configurations.

* Updated the `runs-on:` field to use the `matrix.platform` value instead of the `env.platform` value. This change is in line with the switch to a matrix strategy.

* Updated the `run:` field in the "Generate the cache key" step to use the `matrix.platform` and `matrix.arch` values instead of the `env.platform` and `env.arch` values. This change ensures that the cache key is generated correctly based on the matrix values.

* Updated the `if:` conditions in various steps to use the `matrix.platform` value instead of the `env.platform` value. This change ensures that the correct steps are executed based on the platform defined in the matrix. [[1]](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL44-R46) [[2]](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL58-R73)

* Removed the `scan_build` environment variable and the corresponding conditional logic. This simplifies the workflow as the `scan_build` variable was not being used elsewhere.

* Changed the `DCMAKE_BUILD_TYPE` value from a variable (`env.build_type`) to a fixed string ("Debug"). This change simplifies the workflow and ensures that the build type is always "Debug" for this job.