### PR TITLE
Truncate all ALU32 except for bit-endianess

### DIFF
--- a/vm/ubpf_jit_x86_64.c
+++ b/vm/ubpf_jit_x86_64.c
@@ -769,6 +769,12 @@ translate(struct ubpf_vm* vm, struct jit_state* state, char** errmsg)
             state->jit_status = UnknownInstruction;
             *errmsg = ubpf_error("Unknown instruction at PC %d: opcode %02x", i, inst.opcode);
         }
+
+        // If this is a ALU32 instruction, truncate the target register to 32 bits.
+        if (((inst.opcode & EBPF_CLS_MASK) == EBPF_CLS_ALU) &&
+            (inst.opcode & EBPF_ALU_OP_MASK) != 0xd0) {
+            emit_truncate_u32(state, dst);
+        }
     }
 
     if (state->jit_status != NoError) {

--- a/vm/ubpf_jit_x86_64.h
+++ b/vm/ubpf_jit_x86_64.h
@@ -225,6 +225,12 @@ emit_alu32_imm8(struct jit_state* state, int op, int src, int dst, int8_t imm)
     emit1(state, imm);
 }
 
+static inline void
+emit_truncate_u32(struct jit_state* state, int destination)
+{
+    emit_alu32_imm32(state, 0x81, 4, destination, UINT32_MAX);
+}
+
 /* REX.W prefix and ModRM byte */
 /* We use the MR encoding when there is a choice */
 /* 'src' is often used as an opcode extension */

--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -737,7 +737,7 @@ ubpf_exec_ex(
             }
             break;
         case EBPF_OP_JEQ32_REG:
-            if (u32(reg[inst.dst]) == reg[inst.src]) {
+            if (u32(reg[inst.dst]) == u32(reg[inst.src])) {
                 pc += inst.offset;
             }
             break;
@@ -1002,6 +1002,9 @@ ubpf_exec_ex(
             // Because we have already validated, we can assume that the type code is
             // valid.
             break;
+        }
+        if (((inst.opcode & EBPF_CLS_MASK) == EBPF_CLS_ALU) && (inst.opcode & EBPF_ALU_OP_MASK) != 0xd0) {
+            reg[inst.dst] &= UINT32_MAX;
         }
     }
 
@@ -1371,7 +1374,6 @@ ubpf_get_registers(const struct ubpf_vm* vm)
     fprintf(stderr, "uBPF warning: registers are not exposed in release mode. Please recompile in debug mode\n");
     return NULL;
 }
-
 #endif
 
 typedef struct _ebpf_encoded_inst


### PR DESCRIPTION
All ALU32 operations are supposed to truncate the target register. Adding code to ensure that this is always done.