### PR TITLE
Pin dependencies

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v4.1.6
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       with:
         submodules: 'recursive'
 
@@ -32,7 +32,7 @@ jobs:
       run: echo "VALUE=platform-${{ matrix.platform }}_arch=${{ matrix.arch }}_type=fuzzing" >> $GITHUB_OUTPUT
 
     - name: Update the cache (ccache)
-      uses: actions/cache@v4.0.2
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: ccache
         key: ${{ steps.cache_key.outputs.VALUE }}_ccache
@@ -102,18 +102,18 @@ jobs:
           --build build
 
     - name: Upload fuzzer as artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
       with:
         name: fuzzer
         path: build/bin/ubpf_fuzzer
 
-    - uses: actions/checkout@v4.1.6
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       with:
         submodules: 'recursive'
         ref: fuzz/corpus
 
     - name: Download fuzzer artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281
       with:
         name: fuzzer
 
@@ -142,7 +142,7 @@ jobs:
 
     - name: Upload artifacts
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
       with:
         name: fuzzing-artifacts
         path: artifacts/


### PR DESCRIPTION
This pull request includes changes to the `fuzzing.yml` workflow file in the `.github/workflows` directory. The changes primarily involve updating the versions of the GitHub Actions used in the workflow. The versions of `actions/checkout`, `actions/cache`, and `actions/upload-artifact` have been updated to specific commit hashes instead of version tags.

Here are the key changes:

- [`.github/workflows/fuzzing.yml`](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL26-R26): The `actions/checkout` action has been updated from version `v4.1.6` to commit hash `a5ac7e51b41094c92402da3b24376905380afc29`. This change occurs twice in the workflow, once at the beginning and once later in the workflow. [[1]](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL26-R26) [[2]](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL105-R116)
- [`.github/workflows/fuzzing.yml`](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL35-R35): The `actions/cache` action has been updated from version `v4.0.2` to commit hash `0c45773b623bea8c8e75f6c82b208c3cf94ea4f9`.
- [`.github/workflows/fuzzing.yml`](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL105-R116): The `actions/upload-artifact` action has been updated from version `v2` to commit hash `82c141cc518b40d92cc801eee768e7aafc9c2fa2`. This change occurs twice in the workflow. [[1]](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL105-R116) [[2]](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL145-R145)
- [`.github/workflows/fuzzing.yml`](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL105-R116): The `actions/download-artifact` action has been updated from version `v4` to commit hash `65a9edc5881444af0b9093a5e628f2fe47ea3b2e`.