### PR TITLE
Enable codeql

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -311,6 +311,40 @@ jobs:
       enable_sanitizers: true
       disable_retpolines: true
 
+  linux_release_codeql:
+    uses: ./.github/workflows/posix.yml
+    with:
+      arch: x86_64
+      platform: ubuntu-latest
+      build_type: RelWithDebInfo
+      build_codeql: true
+
+  linux_debug_codeql:
+    uses: ./.github/workflows/posix.yml
+    with:
+      arch: x86_64
+      platform: ubuntu-latest
+      build_type: Debug
+      build_codeql: true
+
+  linux_release_no_retpolines_codeql:
+    uses: ./.github/workflows/posix.yml
+    with:
+      arch: x86_64
+      platform: ubuntu-latest
+      build_type: RelWithDebInfo
+      build_codeql: true
+      disable_retpolines: true
+
+  linux_debug_no_retpolines_codeql:
+    uses: ./.github/workflows/posix.yml
+    with:
+      arch: x86_64
+      platform: ubuntu-latest
+      build_type: Debug
+      build_codeql: true
+      disable_retpolines: true
+
   # Disabled until https://github.com/iovisor/ubpf/issues/155 is resolved.
   # linux_debug_arm64_sanitizers:
   #   uses: ./.github/workflows/posix.yml


### PR DESCRIPTION
This pull request introduces changes to the GitHub Actions workflow configuration in the `.github/workflows/main.yml` file. The changes involve the addition of four new jobs for CodeQL analysis on different build types and configurations.

The key changes are:

* Addition of new CodeQL analysis jobs:
  * [`linux_release_codeql`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R314-R347): This job uses the `posix.yml` workflow to run a CodeQL analysis on a `RelWithDebInfo` build type on `ubuntu-latest` platform with `x86_64` architecture.
  * [`linux_debug_codeql`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R314-R347): Similar to the above job, but runs the CodeQL analysis on a `Debug` build type.
  * [`linux_release_no_retpolines_codeql`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R314-R347): This job is similar to the `linux_release_codeql` job but with `disable_retpolines` set to `true`.
  * [`linux_debug_no_retpolines_codeql`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R314-R347): This job is similar to the `linux_debug_codeql` job but with `disable_retpolines` set to `true`.

These changes enhance the security of the codebase by using CodeQL to automatically detect common vulnerabilities and coding errors.