### PR TITLE
Don't attempt to capture stack usage for inner most bpf2bpf call

### DIFF
--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -425,7 +425,7 @@ ubpf_exec_ex(
             goto cleanup;
         }
 
-        if (pc == 0 || vm->int_funcs[pc]) {
+        if ((pc == 0 || vm->int_funcs[pc]) && stack_frame_index < UBPF_MAX_CALL_DEPTH) {
             stack_frames[stack_frame_index].stack_usage = ubpf_stack_usage_for_local_func(vm, pc);
         }
 


### PR DESCRIPTION
On the inner most bpf2bpf call, the code attempts to capture the stack usage. This results in overwriting the bounds of the stack_frames array.

Resolves: #481