### PR TITLE
Update to macos-latest

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -75,7 +75,7 @@ jobs:
       shell: bash
 
     - name: Install system dependencies (macOS)
-      if: matrix.platform == 'macos-11'
+      if: matrix.platform == 'macos-latest'
       run: |
         brew install \
           cmake \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: macos-11
+      platform: macos-latest
       build_type: RelWithDebInfo
       upload_packages: true
 
@@ -74,7 +74,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: macos-11
+      platform: macos-latest
       build_type: RelWithDebInfo
       upload_packages: true
       disable_retpolines: true
@@ -83,7 +83,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: macos-11
+      platform: macos-latest
       build_type: RelWithDebInfo
       enable_coverage: true
 
@@ -91,7 +91,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: macos-11
+      platform: macos-latest
       build_type: RelWithDebInfo
       enable_coverage: true
       disable_retpolines: true
@@ -100,7 +100,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: macos-11
+      platform: macos-latest
       build_type: RelWithDebInfo
       enable_sanitizers: true
 
@@ -108,7 +108,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: macos-11
+      platform: macos-latest
       build_type: RelWithDebInfo
       enable_sanitizers: true
       disable_retpolines: true
@@ -118,14 +118,14 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: macos-11
+      platform: macos-latest
       build_type: Debug
 
   macos_debug_no_retpolines:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: macos-11
+      platform: macos-latest
       build_type: Debug
       disable_retpolines: true
 
@@ -134,7 +134,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: macos-11
+      platform: macos-latest
       build_type: Debug
       enable_coverage: true
 
@@ -142,7 +142,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: macos-11
+      platform: macos-latest
       build_type: Debug
       enable_coverage: true
       disable_retpolines: true
@@ -151,7 +151,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: macos-11
+      platform: macos-latest
       build_type: Debug
       enable_sanitizers: true
 
@@ -159,7 +159,7 @@ jobs:
     uses: ./.github/workflows/posix.yml
     with:
       arch: x86_64
-      platform: macos-11
+      platform: macos-latest
       build_type: Debug
       enable_sanitizers: true
       disable_retpolines: true

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -123,7 +123,7 @@ jobs:
       shell: bash
 
     - name: Install system dependencies (macOS)
-      if: inputs.platform == 'macos-11'
+      if: inputs.platform == 'macos-latest'
       run: |
         brew install \
           cmake \
@@ -192,13 +192,13 @@ jobs:
           --target test
 
     - name: Generate code coverage report
-      if: inputs.enable_coverage == true && inputs.platform == 'macos-11'
+      if: inputs.enable_coverage == true && inputs.platform == 'macos-latest'
       run: |
         mkdir -p coverage
         lcov --capture --directory build --include '${{env.GITHUB_WORKSPACE}}/*' --output-file coverage/lcov.info --ignore-errors inconsistent
 
     - name: Generate code coverage report
-      if: inputs.enable_coverage == true && inputs.platform != 'macos-11'
+      if: inputs.enable_coverage == true && inputs.platform != 'macos-latest'
       run: |
         mkdir -p coverage
         lcov --capture --directory build --include '${{env.GITHUB_WORKSPACE}}/*' --output-file coverage/lcov.info
@@ -291,7 +291,7 @@ jobs:
         retention-days: 5
 
     - name: Upload the macOS TGZ package
-      if: inputs.upload_packages == true && inputs.platform == 'macos-11'
+      if: inputs.upload_packages == true && inputs.platform == 'macos-latest'
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
       with:
         name: macos_tgz_package


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow file `.github/workflows/main.yml`. The changes involve updating the macOS platform version from `macos-11` to `macos-latest` for various jobs in the workflow. 

Here are the key changes:

* `.github/workflows/main.yml`: Updated the macOS platform version for the following jobs:
  * [`macos_release`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L69-R77): This job now uses the `macos-latest` platform instead of `macos-11`.
  * [`macos_release_coverage`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L86-R94): This job now uses the `macos-latest` platform instead of `macos-11`.
  * [`macos_release_sanitizers`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L103-R111): This job now uses the `macos-latest` platform instead of `macos-11`.
  * [`macos_debug`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L121-R128): This job now uses the `macos-latest` platform instead of `macos-11`.
  * [`macos_debug_coverage`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L137-R145): This job now uses the `macos-latest` platform instead of `macos-11`.
  * [`macos_debug_sanitizers`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L154-R162): This job now uses the `macos-latest` platform instead of `macos-11`.

These changes will ensure that the GitHub Actions workflows run on the latest version of macOS, potentially benefiting from any updates or improvements made in the latest version.