### PR TITLE
Make le16 and le32 truncate on x64

### DIFF
--- a/vm/compat/windows/endian.h
+++ b/vm/compat/windows/endian.h
@@ -13,9 +13,9 @@
 
 #include <Winsock2.h>
 
-#define htole16(value) (value)
+#define htole16(value) (uint16_t)(value)
 
-#define htole32(value) (value)
+#define htole32(value) (uint32_t)(value)
 
 #define htole64(value) (value)
 

--- a/vm/ubpf_jit_arm64.c
+++ b/vm/ubpf_jit_arm64.c
@@ -1067,6 +1067,10 @@ translate(struct ubpf_vm* vm, struct jit_state* state, char** errmsg)
                 /* UXTH dst, dst. */
                 emit_instruction(state, 0x53003c00 | (dst << 5) | dst);
             }
+            else if (inst.imm == 32) {
+                /* UXTW dst, dst. */
+                emit_instruction(state, 0x53007c00 | (dst << 5) | dst);
+            }
             break;
         case EBPF_OP_BE:
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__

--- a/vm/ubpf_jit_x86_64.c
+++ b/vm/ubpf_jit_x86_64.c
@@ -431,6 +431,14 @@ translate(struct ubpf_vm* vm, struct jit_state* state, char** errmsg)
             break;
 
         case EBPF_OP_LE:
+            if (inst.imm == 16) {
+                /* Truncate to 16 bits */
+                emit_alu32_imm32(state, 0x81, 4, dst, 0xffff);
+            }
+            else if (inst.imm == 32) {
+                /* Truncate to 32 bits */
+                emit_alu32_imm32(state, 0x81, 4, dst, 0xffffffff);
+            }
             /* No-op */
             break;
         case EBPF_OP_BE:

--- a/vm/ubpf_jit_x86_64.c
+++ b/vm/ubpf_jit_x86_64.c
@@ -431,11 +431,14 @@ translate(struct ubpf_vm* vm, struct jit_state* state, char** errmsg)
             break;
 
         case EBPF_OP_LE:
+            /* x64 instruction set is already little-endian, so no-op except for truncation. */
             if (inst.imm == 16) {
                 /* Truncate to 16 bits */
                 emit_alu32_imm32(state, 0x81, 4, dst, 0xffff);
+            } else if (inst.imm == 32) {
+                /* Truncate to 32 bits */
+                emit_alu32_imm32(state, 0x81, 4, dst, 0xffffffff);
             }
-            /* No-op */
             break;
         case EBPF_OP_BE:
             if (inst.imm == 16) {

--- a/vm/ubpf_jit_x86_64.c
+++ b/vm/ubpf_jit_x86_64.c
@@ -435,10 +435,6 @@ translate(struct ubpf_vm* vm, struct jit_state* state, char** errmsg)
                 /* Truncate to 16 bits */
                 emit_alu32_imm32(state, 0x81, 4, dst, 0xffff);
             }
-            else if (inst.imm == 32) {
-                /* Truncate to 32 bits */
-                emit_alu32_imm32(state, 0x81, 4, dst, 0xffffffff);
-            }
             /* No-op */
             break;
         case EBPF_OP_BE:


### PR DESCRIPTION
This pull request primarily focuses on updating the subproject commit in `external/bpf_conformance` and adding new instructions to the `translate` function in both the `vm/ubpf_jit_arm64.c` and `vm/ubpf_jit_x86_64.c` files. The new instructions are designed to handle specific immediate values in the `EBPF_OP_LE` and `EBPF_OP_BE` cases.

Subproject update:

* [`external/bpf_conformance`](diffhunk://#diff-4c83d0aeb8e3e2e0d8a21794f8e46b59c88fa31939be349410b94f4979813a74L1-R1): Updated the subproject commit from `ce9571054cb6e60ed88bddcfc8cbff19dc31dab6` to `032f73030556d08e98669e1eb9d86cce3dddf464`.

Addition of new instructions:

* [`vm/ubpf_jit_arm64.c`](diffhunk://#diff-854aae9d8e9fac050d2acfa7745f604fa16e119484bdedd095fe441a0a7220f4R1070-R1073): In the `translate` function, added a new condition to handle the case when `inst.imm` equals 32 in the `EBPF_OP_BE` case.
* [`vm/ubpf_jit_x86_64.c`](diffhunk://#diff-faaefdbfc142f09bf9f246a6c93375c692c02451e4f2a58073daa4c350d2c8aeL434-R441): In the `translate` function, added new conditions to handle the cases when `inst.imm` equals 16 or 32 in the `EBPF_OP_LE` case.

Resolves: #487 