### PR TITLE
Shifting 4byte then casting to 8byte may result in unexpected behavior

### DIFF
--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -415,7 +415,7 @@ ubpf_mark_shadow_stack(
         for (size_t test_bit = offset; test_bit < offset + size; test_bit++) {
             // Convert test_bit into offset + mask to test against the shadow stack.
             size_t bit_offset = test_bit / 8;
-            size_t bit_mask = 1 << (test_bit % 8);
+            size_t bit_mask = 1ull << (test_bit % 8);
             shadow_stack[bit_offset] |= bit_mask;
         }
     }
@@ -456,7 +456,7 @@ ubpf_check_shadow_stack(
         for (size_t test_bit = offset; test_bit < offset + size; test_bit++) {
             // Convert test_bit into offset + mask to test against the shadow stack.
             size_t bit_offset = test_bit / 8;
-            size_t bit_mask = 1 << (test_bit % 8);
+            size_t bit_mask = 1ull << (test_bit % 8);
             if ((shadow_stack[bit_offset] & bit_mask) == 0) {
                 return false;
             }


### PR DESCRIPTION
Ensure that the value being shifted is 8bytes before shifting to prevent potential issues when assigning the result to 8byte value.