### PR TITLE
Update JIT to handle overlapping instructions

### DIFF
--- a/tests/call0.data
+++ b/tests/call0.data
@@ -1,0 +1,7 @@
+-- asm
+mov %r0, 0x12345678
+call local next
+next:
+exit
+-- result
+0x12345678

--- a/vm/ubpf_int.h
+++ b/vm/ubpf_int.h
@@ -21,6 +21,7 @@
 #ifndef UBPF_INT_H
 #define UBPF_INT_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <ubpf.h>
 #include "ebpf.h"
@@ -169,5 +170,21 @@ ubpf_stack_usage_for_local_func(const struct ubpf_vm* vm, uint16_t pc);
 
 bool
 ubpf_calculate_stack_usage_for_local_func(const struct ubpf_vm* vm, uint16_t pc, char** errmsg);
+
+/**
+ * @brief Determine whether an eBPF instruction has a fallthrough
+ *
+ * An eBPF instruction has a fallthrough unless the instruction performs
+ * unconditional change in control-flow. Currently, the only instruction
+ * that fits that description is the EXIT.
+ *
+ * @return True if the inst has a fallthrough; false, otherwise.
+ */
+static inline bool
+ubpf_instruction_has_fallthrough(const struct ebpf_inst inst)
+{
+    // The only instruction that does not have a fallthrough is the EXIT.
+    return inst.opcode != EBPF_OP_EXIT;
+}
 
 #endif

--- a/vm/ubpf_jit_support.c
+++ b/vm/ubpf_jit_support.c
@@ -77,13 +77,26 @@ release_jit_state_result(struct jit_state* state, struct ubpf_jit_result* compil
 }
 
 void
-emit_patchable_relative(
-    uint32_t offset, uint32_t target_pc, uint32_t manual_target_offset, struct patchable_relative* table, size_t index)
+emit_patchable_relative_ex(
+    uint32_t offset,
+    uint32_t target_pc,
+    uint32_t manual_target_offset,
+    struct patchable_relative* table,
+    size_t index,
+    bool near)
 {
     struct patchable_relative* jump = &table[index];
     jump->offset_loc = offset;
     jump->target_pc = target_pc;
     jump->target_offset = manual_target_offset;
+    jump->near = near;
+}
+
+void
+emit_patchable_relative(
+    uint32_t offset, uint32_t target_pc, uint32_t manual_target_offset, struct patchable_relative* table, size_t index)
+{
+    emit_patchable_relative_ex(offset, target_pc, manual_target_offset, table, index, false);
 }
 
 void


### PR DESCRIPTION
The interpreter already supports functions that happen to be in more than one function. This patch adds that support to the JIT.

Fixes #437 