### PR TITLE
Improve CLI handling by permitting either std::cin or file for program data

### DIFF
--- a/custom_tests/CMakeLists.txt
+++ b/custom_tests/CMakeLists.txt
@@ -57,7 +57,7 @@ foreach(test_file ${test_descr_files})
             string(REPLACE "/" "\\" test_exe ${test_exe})
             add_test(
                 NAME ${test_name}-Custom
-            COMMAND ${CMAKE_SOURCE_DIR}/custom_tests/windows/test.cmd  ${potential_input_file} ${test_exe}
+            COMMAND ${test_exe} --program ${potential_input_file}
             )
         else()
             add_test(

--- a/custom_tests/srcs/ubpf_custom_test_support.cc
+++ b/custom_tests/srcs/ubpf_custom_test_support.cc
@@ -4,6 +4,8 @@
 #include <cassert>
 #include <cstdint>
 #include <cstring>
+#include <fstream>
+#include <iostream>
 #include <vector>
 #include <string>
 #include <sstream>
@@ -94,5 +96,44 @@ bool ubpf_setup_custom_test(ubpf_vm_up &vm,
 
     assert(error_s == nullptr);
     free(error_s);
+    return true;
+}
+
+bool get_program_string(int argc, char **argv, std::string &program_string, std::string &error)
+{
+    std::vector<std::string> args(argv, argv + argc);
+
+    if (args.size() == 1)
+    {
+        std::string line;
+        while (std::getline(std::cin, line))
+        {
+            program_string += line;
+        }
+    }
+    else if (args.size() == 3 && args[1] == "--program")
+    {
+        std::ifstream file(args[2]);
+        if (file.is_open())
+        {
+            std::string line;
+            while (std::getline(file, line))
+            {
+                program_string += line;
+            }
+            file.close();
+        }
+        else
+        {
+            error = "Failed to open file: " + args[2];
+            return false;
+        }
+    }
+    else
+    {
+        error = "Usage: " + args[0] + " [program]";
+        return false;
+    }
+
     return true;
 }

--- a/custom_tests/srcs/ubpf_custom_test_support.h
+++ b/custom_tests/srcs/ubpf_custom_test_support.h
@@ -56,3 +56,14 @@ bool ubpf_setup_custom_test(ubpf_vm_up &vm,
                        ubpf_jit_fn &jit_fn,
                        std::string &error);
 
+/**
+ * @brief Get the program string object from the command line arguments or stdin.
+ *
+ * @param[in] argc The number of command line arguments.
+ * @param[in] argv The command line arguments.
+ * @param[out] program_string The program string to return.
+ * @param[out] error The error message to return if there is a problem.
+ * @return true If the program string was successfully obtained.
+ * @return false If there was a problem obtaining the program string.
+ */
+bool get_program_string(int argc, char **argv, std::string &program_string, std::string &error);

--- a/custom_tests/srcs/ubpf_test_external_dispatcher_context_overwrite.cc
+++ b/custom_tests/srcs/ubpf_test_external_dispatcher_context_overwrite.cc
@@ -39,18 +39,20 @@ external_dispatcher_validater(unsigned int idx, const struct ubpf_vm* cookie)
 
 int main(int argc, char **argv)
 {
-    std::vector<std::string> args(argv, argv + argc);
     std::string program_string{};
+    std::string error{};
     ubpf_jit_fn jit_fn;
     uint64_t memory{0x123456789};
 
     // The program modifies (eBPF) r0 (see test description) and then invokes
     // a helper function that will be invoked through the external
     // dispatcher.
-    std::getline(std::cin, program_string);
+    if (!get_program_string(argc, argv, program_string, error)) {
+        std::cerr << error << std::endl;
+        return 1;
+    }
 
     std::unique_ptr<ubpf_vm, decltype(&ubpf_destroy)> vm(ubpf_create(), ubpf_destroy);
-    std::string error{};
     if (!ubpf_setup_custom_test(
             vm,
             program_string,

--- a/custom_tests/srcs/ubpf_test_external_dispatcher_simple_context.cc
+++ b/custom_tests/srcs/ubpf_test_external_dispatcher_simple_context.cc
@@ -37,18 +37,20 @@ external_dispatcher_validater(unsigned int idx, const struct ubpf_vm* cookie)
 
 int main(int argc, char **argv)
 {
-    std::vector<std::string> args(argv, argv + argc);
     std::string program_string{};
+    std::string error{};
     ubpf_jit_fn jit_fn;
     uint64_t memory{0x123456789};
 
     // The test program invokes an external function (which is invoked via the registered
     // external helper dispatcher). The result of that external function is given as the
     // result of the eBPF's program execution. Therefore, ...
-    std::getline(std::cin, program_string);
+    if (!get_program_string(argc, argv, program_string, error)) {
+        std::cerr << error << std::endl;
+        return 1;
+    }
 
     std::unique_ptr<ubpf_vm, decltype(&ubpf_destroy)> vm(ubpf_create(), ubpf_destroy);
-    std::string error{};
     if (!ubpf_setup_custom_test(
             vm,
             program_string,

--- a/custom_tests/srcs/ubpf_test_external_stack_contents.cc
+++ b/custom_tests/srcs/ubpf_test_external_stack_contents.cc
@@ -27,11 +27,14 @@ stack_usage_calculator(const struct ubpf_vm* vm, uint16_t pc, void* cookie)
 int
 main(int argc, char** argv)
 {
-    std::vector<std::string> args(argv, argv + argc);
     std::string program_string{};
+    std::string error{};
     ubpf_jit_fn jit_fn;
 
-    std::getline(std::cin, program_string);
+    if (!get_program_string(argc, argv, program_string, error)) {
+        std::cerr << error << std::endl;
+        return 1;
+    }
 
     const size_t stack_size{32};
     uint8_t expected_result[] = {
@@ -41,7 +44,6 @@ main(int argc, char** argv)
     bool success = true;
 
     std::unique_ptr<ubpf_vm, decltype(&ubpf_destroy)> vm(ubpf_create(), ubpf_destroy);
-    std::string error{};
     if (!ubpf_setup_custom_test(
             vm,
             program_string,

--- a/custom_tests/srcs/ubpf_test_frame_pointer.cc
+++ b/custom_tests/srcs/ubpf_test_frame_pointer.cc
@@ -36,11 +36,14 @@ overwrite_stack_usage_calculator(const struct ubpf_vm* vm, uint16_t pc, void* co
 int
 main(int argc, char** argv)
 {
-    std::vector<std::string> args(argv, argv + argc);
     std::string program_string{};
+    std::string error{};
     ubpf_jit_fn jit_fn;
 
-    std::getline(std::cin, program_string);
+    if (!get_program_string(argc, argv, program_string, error)) {
+        std::cerr << error << std::endl;
+        return 1;
+    }
 
     uint64_t no_overwrite_interp_result = 0;
     uint64_t no_overwrite_jit_result = 0;
@@ -50,7 +53,6 @@ main(int argc, char** argv)
     {
 
         std::unique_ptr<ubpf_vm, decltype(&ubpf_destroy)> vm(ubpf_create(), ubpf_destroy);
-        std::string error{};
         if (!ubpf_setup_custom_test(
                 vm,
                 program_string,

--- a/custom_tests/srcs/ubpf_test_jit_unexpected_instruction.cc
+++ b/custom_tests/srcs/ubpf_test_jit_unexpected_instruction.cc
@@ -13,20 +13,23 @@ extern "C"
 
 #include "ubpf_custom_test_support.h"
 
-int main()
+int main(int argc, char** argv)
 {
     std::string expected_error{"Failed to load program: unknown opcode 0x8f at PC 0" };
     ubpf_jit_fn jit_fn;
     std::string program_string;
+    std::string error{};
 
     // The program's first instruction contains an invalid opcode. Attempting to load this
     // program should elicit an error alerting the user to an unknown opcode (see above).
-    std::getline(std::cin, program_string);
+    if (!get_program_string(argc, argv, program_string, error)) {
+        std::cerr << error << std::endl;
+        return 1;
+    }
 
     std::vector<ebpf_inst> program = bytes_to_ebpf_inst(base16_decode(program_string));
 
     ubpf_vm_up vm(ubpf_create(), ubpf_destroy);
-    std::string error{};
 
     if (!ubpf_setup_custom_test(
             vm,

--- a/custom_tests/srcs/ubpf_test_update_dispatcher.cc
+++ b/custom_tests/srcs/ubpf_test_update_dispatcher.cc
@@ -62,16 +62,18 @@ test_helpers_validater(unsigned int idx, const struct ubpf_vm* vm)
 int
 main(int argc, char** argv)
 {
-    std::vector<std::string> args(argv, argv + argc);
     std::string program_string;
+    std::string error{};
     std::string memory_string;
 
-    std::getline(std::cin, program_string);
+    if (!get_program_string(argc, argv, program_string, error)) {
+        std::cerr << error << std::endl;
+        return 1;
+    }
 
     ubpf_jit_fn jit_fn;
     uint64_t memory{0x123456789};
     std::unique_ptr<ubpf_vm, decltype(&ubpf_destroy)> vm(ubpf_create(), ubpf_destroy);
-    std::string error{};
     if (!ubpf_setup_custom_test(
             vm,
             program_string,

--- a/custom_tests/srcs/ubpf_test_update_helpers.cc
+++ b/custom_tests/srcs/ubpf_test_update_helpers.cc
@@ -39,6 +39,7 @@ int main(int argc, char **argv)
 {
     std::vector<std::string> args(argv, argv + argc);
     std::string program_string{};
+    std::string error{};
     bool success{true};
 
     const char memfrob_testcase_name[] = "memfrob";
@@ -99,13 +100,15 @@ int main(int argc, char **argv)
         }
     };
 
-    std::getline(std::cin, program_string);
+    if (!get_program_string(argc, argv, program_string, error)) {
+        std::cerr << error << std::endl;
+        return 1;
+    }
 
     for (auto testcase : test_cases) {
         ubpf_jit_fn jit_fn;
         uint64_t memory{0x123456789};
         std::unique_ptr<ubpf_vm, decltype(&ubpf_destroy)> vm(ubpf_create(), ubpf_destroy);
-        std::string error{};
         if (!ubpf_setup_custom_test(
                 vm,
                 program_string,

--- a/custom_tests/windows/test.cmd
+++ b/custom_tests/windows/test.cmd
@@ -1,4 +1,0 @@
-rem Copyright (c) Microsoft Corporation
-rem SPDX-License-Identifier: Apache-2.0
-
-type %1 | %2


### PR DESCRIPTION
This pull request primarily refactors the way custom tests are set up and executed in the `custom_tests` directory. The changes include modifying the test command in `CMakeLists.txt`, adding a new function to get the program string from command line arguments or standard input, and updating various test files to use this new function.

Changes to test setup:

* [`custom_tests/CMakeLists.txt`](diffhunk://#diff-6f7adf7c9ecbf38bde4f574c7f10ba2bc6c11428160ed66fa010d9a73efb2982L60-R60): Modified the test command to directly execute the test executable with a `--program` argument pointing to the potential input file, instead of using a Windows command script to pipe the input file into the test executable.
* [`custom_tests/srcs/ubpf_custom_test_support.cc`](diffhunk://#diff-f4d6dcea913657efea9606834a3f3e693ca8762d22be66db6d1244aceabeda0eR101-R139): Added a new function `get_program_string` that gets the program string from command line arguments or standard input. This function is used to replace the previous method of getting the program string from standard input in various test files.
* [`custom_tests/srcs/ubpf_custom_test_support.h`](diffhunk://#diff-8ee59fcfd1e3fb68be2d81d9311fb5b63e7e275f28b981ced19b7ba124f3fad1R59-R69): Added a function declaration for `get_program_string`.

Updates to test files:

* Several test files in `custom_tests/srcs/`: Replaced the previous method of getting the program string from standard input with the new `get_program_string` function. This includes error handling for when the program string cannot be obtained. [[1]](diffhunk://#diff-00e6607d1e0e9d371aa614a0b3526b869334420a0693a7751fd56ece1fee809cL42-L53) [[2]](diffhunk://#diff-30bee8af74d7d14335f8179091b7cadb42db7e4df93a888d0f632d0d7bf00179L40-L51) [[3]](diffhunk://#diff-144771bff9063e9d0209067f1ea925e6527c8fbc2c96bba50cfe7cba5265e4b3L30-R37) [[4]](diffhunk://#diff-20c11ac15254751a719d077ce18c787c1e75d7a9632cf6b7a99bdb5b9d52498cL39-R46) [[5]](diffhunk://#diff-342870e654c25a25276f92b634c61de2466d67ba7d263a9f172159a718aeb5acL16-L29) [[6]](diffhunk://#diff-4fdf19acdd78af794fa80ecda9f379d6cd666b269748426ca2e9834034e2cda1L65-L74) [[7]](diffhunk://#diff-c6453ef730246d642b3518755ebbc20b024ddfc74cae3e702cc0c5f58a61d959R42)

Removal of unnecessary files:

* [`custom_tests/windows/test.cmd`](diffhunk://#diff-93f824d5c600cdf8a8ea3e6b83e394b459b56a07437bfb21ece202813508321fL1-L4): Removed this Windows command script as it is no longer used after the modification to the test command in `CMakeLists.txt`.