### PR TITLE
Emit ModRM Correctly When Register R12 Is Used

### DIFF
--- a/tests/ldxb-0offset.data
+++ b/tests/ldxb-0offset.data
@@ -1,0 +1,19 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+mov %r0, 0
+mov %r2, %r1
+mov %r7, %r1
+mov %r8, %r1
+add %r7, 1
+add %r8, 2
+ldxb %r0, [%r2+0]
+ldxb %r7, [%r7+0]
+ldxb %r8, [%r8+0]
+add %r0, %r7
+add %r0, %r8
+exit
+-- mem
+01 02 03
+-- result
+0x06

--- a/tests/ldxb-large-offset.data
+++ b/tests/ldxb-large-offset.data
@@ -1,0 +1,33 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+mov %r2, %r1
+mov %r8, %r1
+ldxb %r2, [%r2+0x80]
+ldxb %r8, [%r8+0x88]
+mov %r0, %r2
+add %r0, %r8
+exit
+-- mem
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+02 bb 11 cc dd ee ff 11
+03 bb 11 cc dd ee ff 11
+-- result
+0x05
+
+

--- a/tests/ldxb-small-offset.data
+++ b/tests/ldxb-small-offset.data
@@ -1,0 +1,31 @@
+# Copyright (c) Big Switch Networks, Inc
+# SPDX-License-Identifier: Apache-2.0
+-- asm
+mov %r2, %r1
+mov %r8, %r1
+ldxb %r2, [%r2+0x08]
+ldxb %r8, [%r8+0x7f]
+mov %r0, %r2
+add %r0, %r8
+exit
+-- mem
+aa bb 11 cc dd ee ff 11
+02 bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 03
+aa bb 11 cc dd ee ff 11
+aa bb 11 cc dd ee ff 11
+-- result
+0x05


### PR DESCRIPTION
When register R12 is used in an instruction requiring a ModRM byte, the semantics and encoding of the instruction are unique. The emit_modrm_and_displacement function did not handle this uniqueness properly. This patch modifies the function to handle the use of R12 correctly.

Fixes #529