### PR TITLE
allow calling helpers larger than MAX_EXT_FUNCS when using dispatcher

### DIFF
--- a/tests/err-call-bad-imm.data
+++ b/tests/err-call-bad-imm.data
@@ -7,4 +7,4 @@ mov %r5, 5
 call 64
 exit
 -- error
-Failed to load code: invalid call immediate at PC 5
+Failed to load code: call to nonexistent function 64 at PC 5

--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -1467,12 +1467,12 @@ validate(const struct ubpf_vm* vm, const struct ebpf_inst* insts, uint32_t num_i
 
         case EBPF_OP_CALL:
             if (inst.src == 0) {
-                if (inst.imm < 0 || inst.imm >= MAX_EXT_FUNCS) {
+                if (inst.imm < 0) {
                     *errmsg = ubpf_error("invalid call immediate at PC %d", i);
                     return false;
                 }
                 if ((vm->dispatcher != NULL && !vm->dispatcher_validate(inst.imm, vm)) ||
-                    (vm->dispatcher == NULL && !vm->ext_funcs[inst.imm])) {
+                    (vm->dispatcher == NULL && (inst.imm >= MAX_EXT_FUNCS || !vm->ext_funcs[inst.imm]))) {
                     *errmsg = ubpf_error("call to nonexistent function %u at PC %d", inst.imm, i);
                     return false;
                 }


### PR DESCRIPTION
As mentioned in #425 , we have dispatcher now, but it is still limited by MAX_EXT_FUNCS. Release this limit when we use dispatcher.