### PR TITLE
Fix actions/upload-artifact version

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -147,7 +147,7 @@ jobs:
 
     - name: Upload artifacts
       if: always()
-      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2
+      uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: fuzzing-artifacts
         path: artifacts/


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/fuzzing.yml` file. The change updates the version of the `upload-artifact` action to the latest version.

* [`.github/workflows/fuzzing.yml`](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL150-R150): Updated `actions/upload-artifact` from `82c141cc518b40d92cc801eee768e7aafc9c2fa2` to `65462800fd760344b1a7b4382951275a0abb4808` (v4.3.3).