### PR TITLE
Rerun tests with logging on failure

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -191,6 +191,12 @@ jobs:
           --build build \
           --target test
 
+    - name: Rerun failed tests with more verbose output
+      if: inputs.platform == 'ubuntu-latest' && failure()
+      working-directory: ${{github.workspace}}/build
+      run: |
+        ctest --rerun-failed --output-on-failure
+
     - name: Generate code coverage report
       if: inputs.enable_coverage == true && inputs.platform == 'macos-latest'
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -78,6 +78,12 @@ jobs:
         cd build
         ctest --output-on-failure --build-config ${{ inputs.build_type }}
 
+    - name: Rerun failed tests with more verbose output
+      if: inputs.platform == 'ubuntu-latest' && failure()
+      working-directory: ${{github.workspace}}/build
+      run: |
+        ctest --rerun-failed --output-on-failure
+
     - name: Generate the TGZ package
       run: |
         cmake `


### PR DESCRIPTION
This pull request introduces a new step to rerun failed tests with more verbose output in the CI workflows for both POSIX and Windows environments. This change aims to improve the debugging process by providing more detailed information when tests fail.

Improvements to CI workflows:

* [`.github/workflows/posix.yml`](diffhunk://#diff-258c8e6cdf61e87e9d94e06c76fb5e23f602423313565dcb8a46afe648587aceR194-R199): Added a step to rerun failed tests with more verbose output if the platform is `ubuntu-latest` and there is a failure. (`[.github/workflows/posix.ymlR194-R199](diffhunk://#diff-258c8e6cdf61e87e9d94e06c76fb5e23f602423313565dcb8a46afe648587aceR194-R199)`)
* [`.github/workflows/windows.yml`](diffhunk://#diff-5ce5c9ff86f58b1f87b35b5227b2e84cb69f022d6741e1854f3e1e181091773cR81-R86): Added a step to rerun failed tests with more verbose output if the platform is `ubuntu-latest` and there is a failure. (`[.github/workflows/windows.ymlR81-R86](diffhunk://#diff-5ce5c9ff86f58b1f87b35b5227b2e84cb69f022d6741e1854f3e1e181091773cR81-R86)`)