### PR TITLE
Fix Windows build of ubpf_fuzzer

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -113,7 +113,7 @@ jobs:
         name: fuzzer-${{ matrix.platform }}-${{ matrix.arch }}
         path: build/bin/ubpf_fuzzer
 
-  windows:
+  build-windows:
     strategy:
       matrix:
         platform:
@@ -168,7 +168,7 @@ jobs:
   run_fuzzer:
     needs:
       - build-posix
-      - windows
+      - build-windows
     strategy:
       matrix:
         platform:

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -184,6 +184,22 @@ jobs:
         submodules: 'recursive'
         ref: fuzz/corpus
 
+    - name: Install system dependencies (Linux)
+      if: matrix.platform == 'ubuntu-24.04'
+      run: |
+        sudo apt-get update
+
+        sudo apt-get install -y \
+          ccache \
+          ninja-build \
+          cmake \
+          lcov \
+          libboost-dev \
+          libboost-program-options-dev \
+          libboost-filesystem-dev \
+          libelf-dev \
+          libyaml-cpp-dev
+
     - name: Download fuzzer artifacts
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       with:

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -13,7 +13,7 @@ on:
   workflow_call:
 
 jobs:
-  posix:
+  build-posix:
     strategy:
       matrix:
         platform:
@@ -113,47 +113,6 @@ jobs:
         name: fuzzer-${{ matrix.platform }}-${{ matrix.arch }}
         path: build/bin/ubpf_fuzzer
 
-    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      with:
-        submodules: 'recursive'
-        ref: fuzz/corpus
-
-    - name: Download fuzzer artifacts
-      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
-      with:
-        name: fuzzer-${{ matrix.platform }}-${{ matrix.arch }}
-
-    - name: Setup directory for fuzzing
-      run: |
-        ls -la
-        mkdir -p new_corpus
-        mkdir -p fuzz/corpus
-        cp -r fuzz/corpus/* new_corpus
-        mkdir -p artifacts
-        chmod a+x ubpf_fuzzer
-
-    - name: Run fuzzing
-      run: |
-        ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=300
-
-    - name: Merge corpus into fuzz/corpus
-      if: ${{ github.event_name == 'schedule' }}
-      run: |
-        ./ubpf_fuzzer -merge=1 fuzz/corpus new_corpus
-        git add fuzz/corpus
-        git config --global user.email 'ubpf@users.noreply.github.com'
-        git config --global user.name 'Github Action'
-        git commit -sm "Update fuzzing corpus"
-        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{github.repository}}.git
-        git push
-
-    - name: Upload artifacts
-      if: always()
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-      with:
-        name: fuzzing-artifacts-${{ matrix.platform }}-${{ matrix.arch }}
-        path: artifacts/
-
   windows:
     strategy:
       matrix:
@@ -205,6 +164,21 @@ jobs:
         name: fuzzer-${{ matrix.platform }}-${{ matrix.arch }}
         path: build/bin/RelWithDebInfo/*
 
+
+  run_fuzzer:
+    needs:
+      - build-posix
+      - windows
+    strategy:
+      matrix:
+        platform:
+          - ubuntu-24.04
+          - windows-latest
+        arch:
+          - x86_64
+
+    runs-on: ${{ matrix.platform }}
+    steps:
     - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       with:
         submodules: 'recursive'
@@ -217,20 +191,21 @@ jobs:
 
     - name: Setup directory for fuzzing
       run: |
-        dir
-        md new_corpus
-        copy fuzz\corpus\* new_corpus
-        md artifacts
+        ls -la
+        mkdir -p new_corpus
+        mkdir -p fuzz/corpus
+        cp -r fuzz/corpus/* new_corpus
+        mkdir -p artifacts
+        chmod a+x ubpf_fuzzer
 
     - name: Run fuzzing
-      shell: cmd
       run: |
-        .\ubpf_fuzzer.exe new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=300
+        ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=300
 
     - name: Merge corpus into fuzz/corpus
       if: ${{ github.event_name == 'schedule' }}
       run: |
-        .\ubpf_fuzzer.exe -merge=1 fuzz/corpus new_corpus
+        ./ubpf_fuzzer -merge=1 fuzz/corpus new_corpus
         git add fuzz/corpus
         git config --global user.email 'ubpf@users.noreply.github.com'
         git config --global user.name 'Github Action'
@@ -244,3 +219,4 @@ jobs:
       with:
         name: fuzzing-artifacts-${{ matrix.platform }}-${{ matrix.arch }}
         path: artifacts/
+

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -190,10 +190,6 @@ jobs:
         sudo apt-get update
 
         sudo apt-get install -y \
-          ccache \
-          ninja-build \
-          cmake \
-          lcov \
           libboost-dev \
           libboost-program-options-dev \
           libboost-filesystem-dev \
@@ -207,12 +203,15 @@ jobs:
 
     - name: Setup directory for fuzzing
       run: |
-        ls -la
+        ls
         mkdir -p new_corpus
         mkdir -p fuzz/corpus
         cp -r fuzz/corpus/* new_corpus
         mkdir -p artifacts
-        chmod a+x ubpf_fuzzer
+
+    - name: Make fuzzer executable
+      if: matrix.platform == 'ubuntu-24.04'
+      run: chmod a+x ubpf_fuzzer
 
     - name: Run fuzzing
       run: |

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -174,6 +174,14 @@ jobs:
       with:
         submodules: 'recursive'
 
+    - name: Cache the build folder
+      uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8
+      env:
+        cache-name: cache-nuget-modules
+      with:
+        path: build
+        key: ${{ matrix.platform }}-${{ matrix.arch }}-${{ hashFiles('**/CMakeLists.txt') }}
+
     - name: Configure uBPF
       run: |
         cmake -S . -B build -DUBPF_ENABLE_LIBFUZZER=1
@@ -182,11 +190,20 @@ jobs:
       run: |
         cmake --build build --config RelWithDebInfo
 
+    - name: Gather dependencies
+      shell: cmd
+      run: |
+        dir "C:\Program Files\Microsoft Visual Studio\2022"
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
+        copy "%VCToolsInstallDir%"\bin\hostx64\x64\clang* build\bin\RelWithDebInfo
+        copy "%VCToolsRedistDir%\x64\Microsoft.VC143.CRT" build\bin\RelWithDebInfo
+        dir build\bin\RelWithDebInfo
+
     - name: Upload fuzzer as artifacts
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:
         name: fuzzer-${{ matrix.platform }}-${{ matrix.arch }}
-        path: build/bin/RelWithDebInfo/ubpf_fuzzer.*
+        path: build/bin/RelWithDebInfo/*
 
     - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       with:
@@ -208,13 +225,12 @@ jobs:
     - name: Run fuzzing
       shell: cmd
       run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
         .\ubpf_fuzzer.exe new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=300
 
     - name: Merge corpus into fuzz/corpus
       if: ${{ github.event_name == 'schedule' }}
       run: |
-        ./ubpf_fuzzer -merge=1 fuzz/corpus new_corpus
+        .\ubpf_fuzzer.exe -merge=1 fuzz/corpus new_corpus
         git add fuzz/corpus
         git config --global user.email 'ubpf@users.noreply.github.com'
         git config --global user.name 'Github Action'

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -13,7 +13,7 @@ on:
   workflow_call:
 
 jobs:
-  build:
+  posix:
     strategy:
       matrix:
         platform:
@@ -98,7 +98,6 @@ jobs:
           -DCMAKE_C_COMPILER=clang \
           -DCMAKE_CXX_COMPILER=clang++ \
           -DUBPF_ENABLE_LIBFUZZER=1 \
-          -DVERIFIER_ENABLE_TESTS=false \
           ${arch_flags}
 
     - name: Build uBPF
@@ -111,7 +110,7 @@ jobs:
     - name: Upload fuzzer as artifacts
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:
-        name: fuzzer
+        name: fuzzer-${{ matrix.platform }}-${{ matrix.arch }}
         path: build/bin/ubpf_fuzzer
 
     - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
@@ -122,7 +121,7 @@ jobs:
     - name: Download fuzzer artifacts
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
       with:
-        name: fuzzer
+        name: fuzzer-${{ matrix.platform }}-${{ matrix.arch }}
 
     - name: Setup directory for fuzzing
       run: |
@@ -152,5 +151,80 @@ jobs:
       if: always()
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:
-        name: fuzzing-artifacts
+        name: fuzzing-artifacts-${{ matrix.platform }}-${{ matrix.arch }}
+        path: artifacts/
+
+  windows:
+    strategy:
+      matrix:
+        platform:
+          - windows-latest
+        arch:
+          - x86_64
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+      with:
+        egress-policy: audit
+
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      with:
+        submodules: 'recursive'
+
+    - name: Configure uBPF
+      run: |
+        cmake -S . -B build -DUBPF_ENABLE_LIBFUZZER=1
+
+    - name: Build uBPF
+      run: |
+        cmake --build build --config RelWithDebInfo
+
+    - name: Upload fuzzer as artifacts
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+      with:
+        name: fuzzer-${{ matrix.platform }}-${{ matrix.arch }}
+        path: build/bin/RelWithDebInfo/ubpf_fuzzer.*
+
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      with:
+        submodules: 'recursive'
+        ref: fuzz/corpus
+
+    - name: Download fuzzer artifacts
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+      with:
+        name: fuzzer-${{ matrix.platform }}-${{ matrix.arch }}
+
+    - name: Setup directory for fuzzing
+      run: |
+        dir
+        md new_corpus
+        copy fuzz\corpus\* new_corpus
+        md artifacts
+
+    - name: Run fuzzing
+      shell: cmd
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
+        .\ubpf_fuzzer.exe new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=300
+
+    - name: Merge corpus into fuzz/corpus
+      if: ${{ github.event_name == 'schedule' }}
+      run: |
+        ./ubpf_fuzzer -merge=1 fuzz/corpus new_corpus
+        git add fuzz/corpus
+        git config --global user.email 'ubpf@users.noreply.github.com'
+        git config --global user.name 'Github Action'
+        git commit -sm "Update fuzzing corpus"
+        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{github.repository}}.git
+        git push
+
+    - name: Upload artifacts
+      if: always()
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+      with:
+        name: fuzzing-artifacts-${{ matrix.platform }}-${{ matrix.arch }}
         path: artifacts/

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -205,7 +205,6 @@ jobs:
       run: |
         ls
         mkdir -p new_corpus
-        mkdir -p fuzz/corpus
         cp -r fuzz/corpus/* new_corpus
         mkdir -p artifacts
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -340,7 +340,7 @@ jobs:
       build_codeql: true
       disable_retpolines: true
 
-  linux_release_fuzzing:
+  fuzzing:
     uses: ./.github/workflows/fuzzing.yml
 
   # Disabled until https://github.com/iovisor/ubpf/issues/155 is resolved.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -61,6 +61,14 @@ jobs:
       with:
         languages: 'cpp'
 
+    - name: Cache the build folder
+      uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8
+      env:
+        cache-name: cache-nuget-modules
+      with:
+        path: build
+        key: ${{ matrix.platform }}-${{ matrix.arch }}-${{ hashFiles('**/CMakeLists.txt') }}-${{ hashFiles('.github/workflows/windows.yml') }}
+
     - name: Configure uBPF
       run: |
         cmake `

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,14 @@ if(UBPF_ENABLE_PACKAGE)
 endif()
 
 if (UBPF_ENABLE_LIBFUZZER)
+  if (PLATFORM_WINDOWS)
+    # Set compiler flags for libfuzzer
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /fsanitize=address /fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fsanitize=address /fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div")
+  endif()
+  set(VERIFIER_ENABLE_TESTS false)
+
+
   add_subdirectory("libfuzzer")
   add_subdirectory("external/ebpf-verifier")
 endif()

--- a/libfuzzer/CMakeLists.txt
+++ b/libfuzzer/CMakeLists.txt
@@ -6,6 +6,11 @@ if (UBPF_SKIP_EXTERNAL)
     return()
 endif()
 
+if (PLATFORM_WINDOWS)
+set(Boost_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/packages/boost/lib/native/include)
+set(Boost_LIBRARY_DIRS ${CMAKE_BINARY_DIR}/packages/boost_filesystem-vc143/lib/native)
+endif()
+
 set(UBPF_FUZZER_INCLUDES "${CMAKE_SOURCE_DIR}/vm"
     "${CMAKE_BINARY_DIR}/vm"
     "${CMAKE_BINARY_DIR}/_deps/gsl-src/include"
@@ -15,7 +20,8 @@ set(UBPF_FUZZER_INCLUDES "${CMAKE_SOURCE_DIR}/vm"
     "${CMAKE_SOURCE_DIR}/external/ebpf-verifier/src"
     "${CMAKE_SOURCE_DIR}/external/ebpf-verifier/src/crab"
     "${CMAKE_SOURCE_DIR}/external/ebpf-verifier/src/crab_utils"
-    "${CMAKE_CURRENT_BINARY_DIR}")
+    "${CMAKE_CURRENT_BINARY_DIR}"
+    "${Boost_INCLUDE_DIRS}")
 
 set(UBPF_FUZZER_LIBS
     ubpf
@@ -52,5 +58,8 @@ add_executable(
 
 target_include_directories("ubpf_fuzzer" PRIVATE ${UBPF_FUZZER_INCLUDES})
 
-target_link_libraries(ubpf_fuzzer PRIVATE ${UBPF_FUZZER_LIBS})
+if (PLATFORM_WINDOWS)
+  set(CMAKE_EXE_LINKER_FLAGS_FUZZERDEBUG libsancov.lib clang_rt.fuzzer_MDd-x86_64.lib)
+endif()
 
+target_link_libraries(ubpf_fuzzer PRIVATE ${UBPF_FUZZER_LIBS})

--- a/libfuzzer/libfuzz_harness.cc
+++ b/libfuzzer/libfuzz_harness.cc
@@ -28,6 +28,16 @@ extern "C"
 #include "test_helpers.h"
 #include <cassert>
 
+#if defined(_MSC_VER)
+#if defined(DEBUG)
+#pragma comment(lib, "clang_rt.fuzzer_MDd-x86_64.lib")
+#pragma comment(lib, "libsancov.lib")
+#else
+#pragma comment(lib, "clang_rt.fuzzer_MD-x86_64.lib")
+#pragma comment(lib, "libsancov.lib")
+#endif
+#endif
+
 /**
  * @brief Class to read the options from the environment and provide them to
  * the fuzzer.
@@ -461,13 +471,13 @@ typedef enum class _address_type
 address_type_t
 ubpf_classify_address(const ubpf_context_t* context, uint64_t register_value)
 {
-    uintptr_t register_value_ptr = reinterpret_cast<uintptr_t>(register_value);
-    uintptr_t stack_start = reinterpret_cast<uintptr_t>(context->stack_start);
-    uintptr_t stack_end = reinterpret_cast<uintptr_t>(context->stack_end);
+    uintptr_t register_value_ptr = static_cast<uintptr_t>(register_value);
+    uintptr_t stack_start = static_cast<uintptr_t>(context->stack_start);
+    uintptr_t stack_end = static_cast<uintptr_t>(context->stack_end);
     uintptr_t context_start = reinterpret_cast<uintptr_t>(context);
     uintptr_t context_end = context_start + sizeof(ubpf_context_t);
-    uintptr_t packet_start = reinterpret_cast<uintptr_t>(context->data);
-    uintptr_t packet_end = reinterpret_cast<uintptr_t>(context->data_end);
+    uintptr_t packet_start = static_cast<uintptr_t>(context->data);
+    uintptr_t packet_end = static_cast<uintptr_t>(context->data_end);
 
     if (register_value_ptr >= stack_start && register_value_ptr < stack_end) {
         return address_type_t::Stack;


### PR DESCRIPTION
This pull request introduces support for Windows in the fuzzing workflow and makes various related adjustments to the build configuration and scripts. The most important changes include adding Windows as a platform in the CI matrix, modifying the build configuration for compatibility with Windows, and updating artifact naming conventions.

### CI/CD Workflow Updates:
* [`.github/workflows/fuzzing.yml`](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cR21): Added Windows as a supported platform in the CI matrix and included platform-specific configuration steps for building and running the fuzzing jobs. [[1]](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cR21) [[2]](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL89-R91) [[3]](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL101-R114) [[4]](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL114-R142) [[5]](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cR151-R158) [[6]](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL155-R172)

### Build Configuration:
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR45-R49): Set compiler flags for libfuzzer and disabled verifier tests when libfuzzer is enabled.
* [`libfuzzer/CMakeLists.txt`](diffhunk://#diff-1741b861004a93abe82df187da3c41bae7ed269806a0fa9a2ef98eff4e41e04aR9-R13): Added Windows-specific include and library paths for Boost, and set linker flags for Windows. [[1]](diffhunk://#diff-1741b861004a93abe82df187da3c41bae7ed269806a0fa9a2ef98eff4e41e04aR9-R13) [[2]](diffhunk://#diff-1741b861004a93abe82df187da3c41bae7ed269806a0fa9a2ef98eff4e41e04aL18-R24) [[3]](diffhunk://#diff-1741b861004a93abe82df187da3c41bae7ed269806a0fa9a2ef98eff4e41e04aL55-R65)

### Code Adjustments:
* [`libfuzzer/libfuzz_harness.cc`](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524R31-R40): Added pragma comments to link necessary libraries on Windows and replaced `reinterpret_cast` with `static_cast` for pointer type conversions. [[1]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524R31-R40) [[2]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524L464-R480)

### Submodule Update:
* [`external/ebpf-verifier`](diffhunk://#diff-0f47f98c433f156a9980e12abb7595d356ac1690a2e6ddbc3d51f7a4f0c7621eL1-R1): Updated the submodule to a new commit.