### PR TITLE
Only permit jumps within sub-programs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,6 @@ if (UBPF_ENABLE_LIBFUZZER)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /fsanitize=address /fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fsanitize=address /fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div")
   endif()
-  set(VERIFIER_ENABLE_TESTS false)
-
-
   add_subdirectory("libfuzzer")
   add_subdirectory("external/ebpf-verifier")
 endif()

--- a/libfuzzer/libfuzz_harness.cc
+++ b/libfuzzer/libfuzz_harness.cc
@@ -657,8 +657,6 @@ bool bounds_check(void* context, uint64_t addr, uint64_t size)
 }
 
 const std::set<std::string> g_error_message_to_ignore{
-    "Call to local function at pc [0-9]+ is not from a call instruction.",
-    "Instruction limit exceeded",
 };
 
 /**
@@ -816,7 +814,7 @@ split_input(const uint8_t* data, std::size_t size, std::vector<uint8_t>& program
  * @retval 0 The input is valid and processed.
  */
 int
-LLVMFuzzerTestOneInput(const uint8_t* data, std::size_t size)
+LLVMFuzzerTestOneInput(const uint8_t* data, std::size_t size) try
 {
     // Assume the fuzzer input is as follows:
     // 32-bit program length
@@ -878,4 +876,8 @@ LLVMFuzzerTestOneInput(const uint8_t* data, std::size_t size)
     // Program executed successfully.
     // Add it to the corpus as it may be interesting.
     return 0;
+}
+catch (const std::exception& ex) {
+    std::cerr << "Exception: " << ex.what() << std::endl;
+    throw;
 }

--- a/tests/err-call-invalid-jump.data
+++ b/tests/err-call-invalid-jump.data
@@ -1,0 +1,13 @@
+-- asm
+begin:
+mov %r1, 0x12345678
+call local next
+exit
+next:
+add %r1, 1
+ja begin # Intentionally jump from the sub-program back to the main program.
+exit
+-- result
+0x12345678
+-- errror
+Failed to load code: jump out of bounds at PC 4

--- a/tests/err-call0.data
+++ b/tests/err-call0.data
@@ -5,3 +5,5 @@ next:
 exit
 -- result
 0x12345678
+-- error
+Failed to load code: sub-program does not end with EXIT at PC 1


### PR DESCRIPTION
This pull request includes several changes to improve the robustness and functionality of the eBPF verifier and the UBPF virtual machine. The most significant changes involve adding error handling to the fuzzer harness, updating the submodule for the eBPF verifier, and enhancing the UBPF VM to ensure the integrity of sub-programs.

### Error Handling Improvements:
* [`libfuzzer/libfuzz_harness.cc`](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524L819-R817): Added try-catch block in `LLVMFuzzerTestOneInput` to catch and log exceptions, improving error handling during fuzz testing. [[1]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524L819-R817) [[2]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524R880-R883)

### Submodule Update:
* [`external/ebpf-verifier`](diffhunk://#diff-0f47f98c433f156a9980e12abb7595d356ac1690a2e6ddbc3d51f7a4f0c7621eL1-R1): Updated the submodule commit to a newer version, likely including various improvements and bug fixes.

### UBPF VM Enhancements:
* [`vm/ubpf_vm.c`](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fR1422-R1433): Introduced a new function `check_for_self_contained_sub_programs` to ensure that sub-programs only enter via calls and exit properly, preventing jumps out of one program into another. This change includes several helper functions for sorting and deduplicating arrays. [[1]](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fR1422-R1433) [[2]](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fL1718-R1717) [[3]](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fR1964-R2102)
* Removed checks for undefined behavior related to local function calls, simplifying the code and relying on the new sub-program validation logic. [[1]](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fL707-L716) [[2]](diffhunk://#diff-45bc22963d9274fb910b15adf80be8ac6b9cb8a40b6a57bee0a92f821116b32fL1405-L1406)

### Test Data Update:
* [`tests/err-call0.data`](diffhunk://#diff-0ab9e4f5713053dcb1c7f879a5ddcac3e304bb94b402e102c240786c35fa0401R8-R9): Added an error message to the test data to reflect the new validation logic for sub-programs.