### PR TITLE
Switch to fuzzing branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/Alan-Jowett/bpf_conformance.git
 [submodule "external/ebpf-verifier"]
 	path = external/ebpf-verifier
-	url = https://github.com/vbpf/ebpf-verifier.git
+	url = https://github.com/alan-jowett/ebpf-verifier.git


### PR DESCRIPTION
This pull request includes updates to the `.gitmodules` file and the `external/ebpf-verifier` submodule to point to a different repository and commit, respectively.

Submodule updates:

* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L9-R9): Changed the URL for the `external/ebpf-verifier` submodule to `https://github.com/alan-jowett/ebpf-verifier.git` from the previous URL.
* [`external/ebpf-verifier`](diffhunk://#diff-0f47f98c433f156a9980e12abb7595d356ac1690a2e6ddbc3d51f7a4f0c7621eL1-R1): Updated the submodule commit to `71a500ce9bbe33cb48eff075f0f859b8cb62df74` from the previous commit.