### PR TITLE
Mark register as uninitialized if source is uninitialized stack

### DIFF
--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -444,7 +444,7 @@ ubpf_check_shadow_stack(
     uintptr_t stack_end = stack_start + stack_length;
 
     if (access_start > access_end) {
-        // Overflow
+        // Not a stack location.
         return true;
     }
 
@@ -929,8 +929,7 @@ ubpf_exec_ex(
     do {                                                                                                  \
         if (!ubpf_check_shadow_stack(                                                                     \
                 vm, stack_start, stack_length, shadow_stack, (char*)reg[inst.src] + inst.offset, size)) { \
-            return_value = -1;                                                                            \
-            goto cleanup;                                                                                 \
+                shadow_registers &= ~REGISTER_TO_SHADOW_MASK(inst.dst);                                   \
         }                                                                                                 \
         if (!bounds_check(                                                                                \
                 vm,                                                                                       \


### PR DESCRIPTION
Loading an uninitialized value from the stack should mark the destination register as uninitialized.