### PR TITLE
Pull after running fuzzing to avoid conflict

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -235,6 +235,7 @@ jobs:
     - name: Merge corpus into fuzz/corpus
       if: ${{ github.event_name == 'schedule' }}
       run: |
+        git pull
         ./ubpf_fuzzer -merge=1 fuzz/corpus new_corpus
         git add fuzz/corpus
         git config --global user.email 'ubpf@users.noreply.github.com'


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/fuzzing.yml` file. The change ensures that the latest updates are pulled from the repository before merging the corpus during scheduled events.

* [`.github/workflows/fuzzing.yml`](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cR238): Added a `git pull` command to ensure the latest updates are included before running the corpus merge.