### PR TITLE
Increase runtime

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -241,7 +241,7 @@ jobs:
 
     # If this is a scheduled run or a manual run, run ubpf_fuzzer to attempt to find new crashes. Runs for 2 hours.
     - name: Run fuzzing
-      if: matrix.platform == 'ubuntu-24.04' && inputs.regression_test != true
+      if: matrix.platform == 'windows-latest' && inputs.regression_test != true
       run: |
         ls
         ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=7200 -jobs=1024

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -230,7 +230,7 @@ jobs:
     - name: Run fuzzing regression
       if: inputs.regression_test == true
       run: |
-        ./ubpf_fuzzer -merge fuzz/corpus new_corpus
+        ./ubpf_fuzzer -merge=1 fuzz/corpus new_corpus
 
     # If this is a scheduled run or a manual run, run ubpf_fuzzer to attempt to find new crashes. Runs for 2 hours.
     - name: Run fuzzing

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -220,23 +220,32 @@ jobs:
       if: matrix.platform == 'ubuntu-24.04'
       run: chmod a+x ubpf_fuzzer
 
+    # If this is a workflow call, run ubpf_fuzzer over each file in the corpus as a regression test.
+    - name: Run fuzzing regression
+      if: github.event_name == 'workflow_call'
+      run: |
+        ./ubpf_fuzzer -merge fuzz/corpus new_corpus
+
+    # If this is a scheduled run or a manual run, run ubpf_fuzzer to attempt to find new crashes. Runs for 2 hours.
     - name: Run fuzzing
-      if: matrix.platform == 'ubuntu-24.04'
+      if: matrix.platform == 'ubuntu-24.04' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
       run: |
         ls
-        UBPF_FUZZER_CONSTRAINT_CHECK=1 ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=300 -dict=dictionary.txt
+        UBPF_FUZZER_CONSTRAINT_CHECK=1 ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=7200 -dict=dictionary.txt
 
+    # If this is a scheduled run or a manual run, run ubpf_fuzzer to attempt to find new crashes. Runs for 2 hours.
     - name: Run fuzzing
-      if: matrix.platform == 'windows-latest'
+      if: matrix.platform == 'ubuntu-24.04' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
       run: |
         ls
-        ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=300
+        ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=7200
 
+    # Merge the new corpus into the existing corpus and push the changes to the repository.
     - name: Merge corpus into fuzz/corpus
-      if: ${{ github.event_name == 'schedule' }}
+      if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
       run: |
-        git pull
         ./ubpf_fuzzer -merge=1 fuzz/corpus new_corpus
+        git pull
         git add fuzz/corpus
         git config --global user.email 'ubpf@users.noreply.github.com'
         git config --global user.name 'Github Action'

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -11,6 +11,12 @@ on:
     - cron: '00 21 * * *'
   workflow_dispatch: # Run manually
   workflow_call:
+    inputs:
+      regression_test:
+        description: 'Run the fuzzer over the corpus as a regression test.'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build-posix:
@@ -222,27 +228,27 @@ jobs:
 
     # If this is a workflow call, run ubpf_fuzzer over each file in the corpus as a regression test.
     - name: Run fuzzing regression
-      if: github.event_name == 'workflow_call'
+      if: inputs.regression_test == true
       run: |
         ./ubpf_fuzzer -merge fuzz/corpus new_corpus
 
     # If this is a scheduled run or a manual run, run ubpf_fuzzer to attempt to find new crashes. Runs for 2 hours.
     - name: Run fuzzing
-      if: matrix.platform == 'ubuntu-24.04' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+      if: matrix.platform == 'ubuntu-24.04' && inputs.regression_test != true
       run: |
         ls
-        UBPF_FUZZER_CONSTRAINT_CHECK=1 ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=7200 -dict=dictionary.txt
+        UBPF_FUZZER_CONSTRAINT_CHECK=1 ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=7200 -dict=dictionary.txt -jobs=1024
 
     # If this is a scheduled run or a manual run, run ubpf_fuzzer to attempt to find new crashes. Runs for 2 hours.
     - name: Run fuzzing
-      if: matrix.platform == 'ubuntu-24.04' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+      if: matrix.platform == 'ubuntu-24.04' && inputs.regression_test != true
       run: |
         ls
-        ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=7200
+        ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=7200 -jobs=1024
 
     # Merge the new corpus into the existing corpus and push the changes to the repository.
     - name: Merge corpus into fuzz/corpus
-      if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      if: inputs.regression_test != true
       run: |
         ./ubpf_fuzzer -merge=1 fuzz/corpus new_corpus
         git pull

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -342,6 +342,8 @@ jobs:
 
   fuzzing:
     uses: ./.github/workflows/fuzzing.yml
+    with:
+      regression_test: true
 
   # Disabled until https://github.com/iovisor/ubpf/issues/155 is resolved.
   # linux_debug_arm64_sanitizers:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -343,7 +343,7 @@ jobs:
   fuzzing:
     uses: ./.github/workflows/fuzzing.yml
     with:
-      regression_test: true
+      regression_test: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' }}
 
   # Disabled until https://github.com/iovisor/ubpf/issues/155 is resolved.
   # linux_debug_arm64_sanitizers:


### PR DESCRIPTION
This pull request includes updates to the fuzzing workflow configuration to improve runtime flexibility based on the event type. The key changes involve setting a default runtime for fuzzing and adjusting it for scheduled jobs.

### Workflow Configuration Updates:

* [`.github/workflows/fuzzing.yml`](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cR212-R226): Added a default runtime of 5 minutes for the fuzzer and increased the runtime to 2 hours for scheduled or manually triggered jobs.
* [`.github/workflows/fuzzing.yml`](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL227-R248): Updated the fuzzer execution command to use the runtime specified in the environment variable `UBPF_FUZZER_RUNTIME`.