### PR TITLE
Fix integer widths

### DIFF
--- a/vm/ubpf_instruction_valid.c
+++ b/vm/ubpf_instruction_valid.c
@@ -954,7 +954,7 @@ static void _initialize_lookup_table()
         return;
     }
 
-    for (int i = 0; i < sizeof(_ubpf_instruction_filter) / sizeof(_ubpf_instruction_filter[0]); i++) {
+    for (size_t i = 0; i < sizeof(_ubpf_instruction_filter) / sizeof(_ubpf_instruction_filter[0]); i++) {
         _ubpf_filter_instruction_lookup_table[_ubpf_instruction_filter[i].opcode] = &_ubpf_instruction_filter[i];
     }
 
@@ -962,7 +962,7 @@ static void _initialize_lookup_table()
 }
 
 
-static bool _in_range(int value, int lower_bound, int upper_bound)
+static bool _in_range(int32_t value, int32_t lower_bound, int32_t upper_bound)
 {
     return value >= lower_bound && value <= upper_bound;
 }


### PR DESCRIPTION
This pull request includes changes to the `vm/ubpf_instruction_valid.c` file to improve type safety and consistency in the `_initialize_lookup_table` and `_in_range` functions.

Improvements to type safety and consistency:

* [`vm/ubpf_instruction_valid.c`](diffhunk://#diff-9f21b38f4b43f04732f43980ba8a33b4a4c6e528129cb9d40d0e5a044b0348faL957-R965): Changed the loop variable type from `int` to `size_t` in the `_initialize_lookup_table` function to ensure proper handling of the loop index.
* [`vm/ubpf_instruction_valid.c`](diffhunk://#diff-9f21b38f4b43f04732f43980ba8a33b4a4c6e528129cb9d40d0e5a044b0348faL957-R965): Updated the parameter types in the `_in_range` function from `int` to `int32_t` for better consistency and clarity.