### PR TITLE
Update verifier

### DIFF
--- a/libfuzzer/libfuzz_harness.cc
+++ b/libfuzzer/libfuzz_harness.cc
@@ -521,7 +521,7 @@ ubpf_debug_function(
             if ((register_mask & (1 << i)) == 0) {
                 continue;
             }
-            std::cout << "r" << i << "=" << registers[i] << " ";
+            std::cout << "r" << i << "=" << std::hex << registers[i] << " ";
         }
         std::cout << std::endl;
     }


### PR DESCRIPTION
This pull request includes changes to the `external/ebpf-verifier` submodule and an update to the debugging output in `libfuzzer/libfuzz_harness.cc`. The most important changes are:

Submodule update:

* [`external/ebpf-verifier`](diffhunk://#diff-0f47f98c433f156a9980e12abb7595d356ac1690a2e6ddbc3d51f7a4f0c7621eL1-R1): Updated the submodule commit to the latest version.

Debugging improvements:

* [`libfuzzer/libfuzz_harness.cc`](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524L524-R524): Modified the `ubpf_debug_function` to print register values in hexadecimal format for better readability.