### PR TITLE
Set timeout correctly

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -237,14 +237,14 @@ jobs:
       if: matrix.platform == 'ubuntu-24.04' && inputs.regression_test != true
       run: |
         ls
-        UBPF_FUZZER_CONSTRAINT_CHECK=1 ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=7200 -dict=dictionary.txt -jobs=1024
+        UBPF_FUZZER_CONSTRAINT_CHECK=1 ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=3600 -dict=dictionary.txt
 
     # If this is a scheduled run or a manual run, run ubpf_fuzzer to attempt to find new crashes. Runs for 2 hours.
     - name: Run fuzzing
       if: matrix.platform == 'windows-latest' && inputs.regression_test != true
       run: |
         ls
-        ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=7200 -jobs=1024
+        ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=3600
 
     # Merge the new corpus into the existing corpus and push the changes to the repository.
     - name: Merge corpus into fuzz/corpus


### PR DESCRIPTION
This pull request includes changes to the fuzzing job configurations in the `.github/workflows/fuzzing.yml` file to adjust the maximum total run time for the fuzzing process.

Changes to fuzzing job configurations:

* Reduced the `max_total_time` for the `ubpf_fuzzer` from 7200 seconds to 3600 seconds for both the `ubuntu-24.04` and `windows-latest` platforms.