### PR TITLE
Fix labelling for local calls

### DIFF
--- a/libfuzzer/CMakeLists.txt
+++ b/libfuzzer/CMakeLists.txt
@@ -30,20 +30,6 @@ set(UBPF_FUZZER_LIBS
 
 set(CMAKE_REQUIRED_INCLUDES ${UBPF_FUZZER_INCLUDES})
 
-include(CheckCXXSourceCompiles)
-
-# Check if the ebpf verifier supports checking constraints at labels.
-set(CHECK_CONFIG_STORE_PRE_INVARIANTS "
-#include <config.hpp>
-int main() {
-    ebpf_verifier_options_t options;
-    options.store_pre_invariants = true;
-    return 0;
-}
-")
-
-check_cxx_source_compiles("${CHECK_CONFIG_STORE_PRE_INVARIANTS}" HAVE_EBPF_VERIFIER_CHECK_CONSTRAINTS_AT_LABEL)
-
 set(CMAKE_CXX_STANDARD 20)
 
 configure_file(


### PR DESCRIPTION
This pull request includes several updates to the `libfuzzer` harness to enhance the functionality and remove outdated checks. The most important changes involve adding new fields to the `ubpf_context_t` structure, removing conditional compilation checks, and updating function signatures to include the program code.

### Enhancements to `ubpf_context_t` structure:

* Added `program_start` and `program_end` fields to the `ubpf_context_t` structure to track the program boundaries. (`libfuzzer/libfuzz_harness.cc`)

### Removal of outdated checks and conditional compilation:

* Removed the `HAVE_EBPF_VERIFIER_CHECK_CONSTRAINTS_AT_LABEL` conditional compilation checks and related code, simplifying the handling of `store_pre_invariants` option. (`libfuzzer/libfuzz_harness.cc`) [[1]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524L362-L364) [[2]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524R531-R561) [[3]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524L594-L600)

### Function signature updates:

* Updated the `ubpf_context_from` function to accept `program_code` as a parameter and initialize the new fields in `ubpf_context_t`. (`libfuzzer/libfuzz_harness.cc`) [[1]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524L612-R630) [[2]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524R639-R640)
* Modified `call_ubpf_interpreter` and `call_ubpf_jit` functions to pass `program_code` to `ubpf_context_from`. (`libfuzzer/libfuzz_harness.cc`) [[1]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524L690-R710) [[2]](diffhunk://#diff-90d0c71847f23efa012693fe27bf93e459ad6a1b101cb48db77dd6205fbaf524L733-R753)

### Additional changes:

* Added a global vector `g_pc_stack` to track the program counter stack for local calls and exits. (`libfuzzer/libfuzz_harness.cc`)