### PR TITLE
Set timeout on fuzzing

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -237,14 +237,14 @@ jobs:
       if: matrix.platform == 'ubuntu-24.04' && inputs.regression_test != true
       run: |
         ls
-        UBPF_FUZZER_CONSTRAINT_CHECK=1 ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=3600 -dict=dictionary.txt
+        UBPF_FUZZER_CONSTRAINT_CHECK=1 ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=3600 -dict=dictionary.txt -timeout=60
 
     # If this is a scheduled run or a manual run, run ubpf_fuzzer to attempt to find new crashes. Runs for 2 hours.
     - name: Run fuzzing
       if: matrix.platform == 'windows-latest' && inputs.regression_test != true
       run: |
         ls
-        ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=3600
+        ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=3600 -timeout=60
 
     # Merge the new corpus into the existing corpus and push the changes to the repository.
     - name: Merge corpus into fuzz/corpus


### PR DESCRIPTION
This pull request includes a minor update to the fuzzing workflow configuration in the `.github/workflows/fuzzing.yml` file. The change introduces a timeout parameter to the `ubpf_fuzzer` command to prevent it from running indefinitely.

* Added a `-timeout=60` parameter to the `ubpf_fuzzer` command for both Ubuntu and Windows platforms to ensure the fuzzer does not run indefinitely. (`.github/workflows/fuzzing.yml`)