### PR TITLE
Reduce timeout

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -237,14 +237,14 @@ jobs:
       if: matrix.platform == 'ubuntu-24.04' && inputs.regression_test != true
       run: |
         ls
-        UBPF_FUZZER_CONSTRAINT_CHECK=1 ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=3600 -dict=dictionary.txt
+        UBPF_FUZZER_CONSTRAINT_CHECK=1 ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=3600 -dict=dictionary.txt -timeout=60
 
     # If this is a scheduled run or a manual run, run ubpf_fuzzer to attempt to find new crashes. Runs for 2 hours.
     - name: Run fuzzing
       if: matrix.platform == 'windows-latest' && inputs.regression_test != true
       run: |
         ls
-        ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=3600
+        ./ubpf_fuzzer new_corpus -artifact_prefix=artifacts/ -use_value_profile=1 -max_total_time=3600 -timeout=60
 
     # Merge the new corpus into the existing corpus and push the changes to the repository.
     - name: Merge corpus into fuzz/corpus

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -230,7 +230,7 @@ jobs:
     - name: Run fuzzing regression
       if: inputs.regression_test == true
       run: |
-        ./ubpf_fuzzer -merge=1 fuzz/corpus new_corpus
+        ./ubpf_fuzzer -merge=1 fuzz/corpus new_corpus -timeout=60
 
     # If this is a scheduled run or a manual run, run ubpf_fuzzer to attempt to find new crashes. Runs for 2 hours.
     - name: Run fuzzing


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/fuzzing.yml` file to enhance the fuzzing process by adding a timeout parameter to prevent the fuzzer from running indefinitely.

Enhancements to fuzzing process:

* Added a `-timeout=60` parameter to the `ubpf_fuzzer` command in the regression test step to limit the execution time of each fuzzing run. (`.github/workflows/fuzzing.yml`: [.github/workflows/fuzzing.ymlL233-R247](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL233-R247))
* Added a `-timeout=60` parameter to the `ubpf_fuzzer` command for both Ubuntu and Windows platforms in the fuzzing step to ensure each fuzzing attempt is time-bounded. (`.github/workflows/fuzzing.yml`: [.github/workflows/fuzzing.ymlL233-R247](diffhunk://#diff-0d1818478ed3978a08c330da0345293a51e13da847c4f41d494b346c3615b94cL233-R247))