### PR TITLE
Set stack as function of max call depth

### DIFF
--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -40,10 +40,17 @@ extern "C"
 #endif
 
 /**
+ * @brief Default maximum number of nested calls in the VM.
+ */
+#if !defined(UBPF_MAX_CALL_DEPTH)
+#define UBPF_MAX_CALL_DEPTH 8
+#endif
+
+/**
  * @brief Default stack size for the eBPF program. Must be divisible by 16.
  */
 #if !defined(UBPF_EBPF_STACK_SIZE)
-#define UBPF_EBPF_STACK_SIZE (8 * 1024)
+#define UBPF_EBPF_STACK_SIZE (UBPF_MAX_CALL_DEPTH * 512)
 #endif
 
 /**
@@ -60,12 +67,6 @@ extern "C"
 
 #define UBPF_EBPF_NONVOLATILE_SIZE (sizeof(uint64_t) * 5)
 
-/**
- * @brief Default maximum number of nested calls in the VM.
- */
-#if !defined(UBPF_MAX_CALL_DEPTH)
-#define UBPF_MAX_CALL_DEPTH 10
-#endif
 
     /**
      * @brief Opaque type for a the uBPF VM.


### PR DESCRIPTION
This pull request includes changes to the `vm/inc/ubpf.h` file to update the configuration of the uBPF VM. The most important changes involve setting a default maximum number of nested calls and adjusting the default stack size accordingly.

Configuration updates:

* Added a new definition for `UBPF_MAX_CALL_DEPTH` with a default value of 8 if not already defined.
* Adjusted the default stack size (`UBPF_EBPF_STACK_SIZE`) to be calculated based on `UBPF_MAX_CALL_DEPTH`.
* Removed an older definition for `UBPF_MAX_CALL_DEPTH` that set the value to 10.