### PR TITLE
Handle changes to lcov

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -201,7 +201,7 @@ jobs:
       if: inputs.enable_coverage == true && inputs.platform == 'macos-latest'
       run: |
         mkdir -p coverage
-        lcov --capture --directory build --include '${{env.GITHUB_WORKSPACE}}/*' --output-file coverage/lcov.info --ignore-errors inconsistent
+        lcov --ignore-errors inconsistent,format --capture --directory build --include '${{env.GITHUB_WORKSPACE}}/*' --output-file coverage/lcov.info --ignore-errors inconsistent
 
     - name: Generate code coverage report
       if: inputs.enable_coverage == true && inputs.platform != 'macos-latest'


### PR DESCRIPTION
Resolves: #630

This pull request includes a minor change to the `.github/workflows/posix.yml` file. The change modifies the `lcov` command to ignore all errors during the code coverage capture process.

* [`.github/workflows/posix.yml`](diffhunk://#diff-258c8e6cdf61e87e9d94e06c76fb5e23f602423313565dcb8a46afe648587aceL204-R204): Updated the `lcov` command to use the `--ignore-errors all` flag instead of `--ignore-errors inconsistent` to ensure all errors are ignored during the code coverage capture.