### PR TITLE
Prune git submodules in format script

### DIFF
--- a/scripts/format-code
+++ b/scripts/format-code
@@ -257,7 +257,7 @@ fi
 get_file_list()
 {
     if [[ -z "${userFiles[*]}" ]]; then
-        mapfile -t file_list < <(eval "$findargs")
+        mapfile -t file_list < <(eval "$findargs" | grep -v "$(git submodule --quiet foreach 'echo $path/')")
         if [[ ${#file_list[@]} -eq 0 ]]; then
             echo "No files were found to format!"
             exit 1

--- a/scripts/format-code
+++ b/scripts/format-code
@@ -257,6 +257,7 @@ fi
 get_file_list()
 {
     if [[ -z "${userFiles[*]}" ]]; then
+        # Prune formatting files within git submodules
         mapfile -t file_list < <(eval "$findargs" | grep -v "$(git submodule --quiet foreach 'echo $path/')")
         if [[ ${#file_list[@]} -eq 0 ]]; then
             echo "No files were found to format!"


### PR DESCRIPTION
Hey, great project you got going on!

My recent version of clang-format (v19) seems inconsistent with the formatting 
both in this repo and the submodules. So after running `scripts/format-code`, git
told me I had modified files within one of these - namely `vm/compat/libraries/win-c/src`.

I'm still trying to get the correct version of clang setup, but in the meantime I thought
it wouldn't hurt to prune git submodules for the format check. 

I couldn't find a way to prune them through `find`, so I figured I'd use `grep`.

Let me know if this is intentional or if you'd like to see a different solution. 
Thanks!

ps.
These are the files I believe are needlessly getting format checked:

```
./vm/compat/libraries/win-c/src/test/test_getopt_long.cpp
./vm/compat/libraries/win-c/src/test/test.cpp
./vm/compat/libraries/win-c/src/include/getopt.h
./vm/compat/libraries/win-c/src/source/getopt.c
```

Also, note that the other two submodules are currently being pruned as they're in `external/`