### PR TITLE
Issue 510: Wrong conditional for offset check in ELF relocation

### DIFF
--- a/vm/ubpf_loader.c
+++ b/vm/ubpf_loader.c
@@ -364,7 +364,7 @@ ubpf_load_elf_ex(struct ubpf_vm* vm, const void* elf, size_t elf_size, const cha
 
             for (uint i = 0; i < total_functions; i++) {
                 if (sections[relo_applies_to_section].shdr == relocated_functions[i]->shdr &&
-                    relocation.r_offset > relocated_functions[i]->native_section_start &&
+                    relocation.r_offset >= relocated_functions[i]->native_section_start &&
                     relocation.r_offset < relocated_functions[i]->native_section_start + relocated_functions[i]->size) {
                     source_function = relocated_functions[i];
                     break;


### PR DESCRIPTION
Apologies for the VERY small PR, but this prevents loading some ELF files because of the relocation loading process and may block others with similar binaries and might be useful.

As described in Issue 510, I believe that the condition ">" should be ">=" when searching for relocated functions because it is possible (and has happened) that the offset of the relocation is equal to the offset of the function (i.e. the relocation happened at the very first byte of the function).

I therefore believe that the ">" should be changed to ">=" in this loop checking whether the offset is "inside" a particular function.