### PR TITLE
Fix Conformance external project directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,18 +21,17 @@ if(UBPF_ENABLE_TESTS)
 endif()
 
 add_subdirectory("vm")
-    ExternalProject_Add(Conformance
-        INSTALL_COMMAND ""
-        SOURCE_DIR ${CMAKE_SOURCE_DIR}/external/bpf_conformance
-				BINARY_DIR ${CMAKE_BINARY_DIR}/external/bpf_conformance
-        EXCLUDE_FROM_ALL true
-        STEP_TARGETS build)
+
+ExternalProject_Add(Conformance
+    INSTALL_COMMAND ""
+    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/external/bpf_conformance
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/external/bpf_conformance
+    EXCLUDE_FROM_ALL true
+    STEP_TARGETS build)
 
 if(UBPF_ENABLE_TESTS)
   add_subdirectory("custom_tests")
   add_subdirectory("ubpf_plugin")
-  if (NOT UBPF_SKIP_EXTERNAL)
-  endif()
   add_subdirectory("bpf")
   add_subdirectory("aarch64_test")
 endif()


### PR DESCRIPTION
Update the _Conformance_ external project's source and binary directories to enable using _ubpf_ with _ExternalProject_ and _FetchContent_.