### PR TITLE
Fix UBPF_SKIP_EXTERNAL CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,18 +21,19 @@ if(UBPF_ENABLE_TESTS)
 endif()
 
 add_subdirectory("vm")
-    ExternalProject_Add(Conformance
-        INSTALL_COMMAND ""
-        SOURCE_DIR ${CMAKE_SOURCE_DIR}/external/bpf_conformance
-				BINARY_DIR ${CMAKE_BINARY_DIR}/external/bpf_conformance
-        EXCLUDE_FROM_ALL true
-        STEP_TARGETS build)
+
+if(NOT UBPF_SKIP_EXTERNAL)
+  ExternalProject_Add(Conformance
+      INSTALL_COMMAND ""
+      SOURCE_DIR ${CMAKE_SOURCE_DIR}/external/bpf_conformance
+			BINARY_DIR ${CMAKE_BINARY_DIR}/external/bpf_conformance
+      EXCLUDE_FROM_ALL true
+      STEP_TARGETS build)
+endif()
 
 if(UBPF_ENABLE_TESTS)
   add_subdirectory("custom_tests")
   add_subdirectory("ubpf_plugin")
-  if (NOT UBPF_SKIP_EXTERNAL)
-  endif()
   add_subdirectory("bpf")
   add_subdirectory("aarch64_test")
 endif()


### PR DESCRIPTION
As far as I can tell, this was the originally intended purpose of the `UBPF_SKIP_EXTERNAL` flag.

Usecase: I need a way to build without pulling down the (enormous) submodules.