### PR TITLE
MacOS build fails to install cmake

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -126,7 +126,6 @@ jobs:
       if: inputs.platform == 'macos-latest'
       run: |
         brew install \
-          cmake \
           ninja \
           ccache \
           lcov \


### PR DESCRIPTION
This pull request makes a minor update to the macOS build workflow configuration. The change removes the installation of `cmake` from the list of packages installed via Homebrew.

* [`.github/workflows/posix.yml`](diffhunk://#diff-258c8e6cdf61e87e9d94e06c76fb5e23f602423313565dcb8a46afe648587aceL129): Removed `cmake` from the list of packages installed by Homebrew for the macOS build job.