### PR TITLE
Fix Conformance external project directories for FetchContent/ExternalProject usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,8 @@ add_subdirectory("vm")
 if(NOT UBPF_SKIP_EXTERNAL)
   ExternalProject_Add(Conformance
       INSTALL_COMMAND ""
-      SOURCE_DIR ${CMAKE_SOURCE_DIR}/external/bpf_conformance
-			BINARY_DIR ${CMAKE_BINARY_DIR}/external/bpf_conformance
+      SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/bpf_conformance
+      BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/external/bpf_conformance
       EXCLUDE_FROM_ALL true
       STEP_TARGETS build)
 endif()


### PR DESCRIPTION
## Summary

When ubpf is used as a subproject via \ExternalProject\ or \FetchContent\, \CMAKE_SOURCE_DIR\ and \CMAKE_BINARY_DIR\ point to the **parent** project's directories, not ubpf's. This causes the Conformance external project to fail to find the bpf_conformance source.

## Changes

- Changed \CMAKE_SOURCE_DIR\ → \CMAKE_CURRENT_SOURCE_DIR\
- Changed \CMAKE_BINARY_DIR\ → \CMAKE_CURRENT_BINARY_DIR\
- Fixed inconsistent indentation (tab vs spaces) on the BINARY_DIR line

## Credit

This fix is based on the work from PR #660 by @brodeuralexis, which became stale due to merge issues.

Fixes the same issue as #660 (which can be closed after this merges).