### PR TITLE
Add .github/copilot-instructions.md for Copilot integration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -77,7 +77,7 @@ ubpf_jit_fn ubpf_compile(struct ubpf_vm* vm, char** errmsg);
 - LLVM-based style with Mozilla brace rules (see `.clang-format`)
 - 120 column width
 - `clang-format` version 11+ required
-- Note: `docs/Contributing.md` mentions Allman braces, but `.clang-format` is authoritative (Mozilla braces).
+- Note: `docs/Contributing.md` mentions Allman braces and an 80 character column width, but `.clang-format` is authoritative (Mozilla braces, 120 columns).
 
 ### Naming
 - `lower_snake_case` for variables, functions, file names


### PR DESCRIPTION
This PR adds a copilot-instructions.md file to help GitHub Copilot work more effectively in this repository.

## Contents

- **Build and test commands** - Including how to run single tests
- **Architecture overview** - Core VM components, test structure, and key APIs
- **Coding conventions** - Naming, style, types, headers, license requirements, and pre-commit hooks

The instructions are derived from README.md, docs/Contributing.md, and analysis of the codebase structure.