### PR TITLE
libfuzzer: throw from ubpf_get_helper_prototype stub

### DIFF
--- a/libfuzzer/libfuzz_harness.cc
+++ b/libfuzzer/libfuzz_harness.cc
@@ -175,10 +175,17 @@ ubpf_get_map_type(uint32_t platform_specific_type)
 prevail::EbpfHelperPrototype
 ubpf_get_helper_prototype(int32_t n)
 {
-    // Once the fuzzer supports helper functions, this function should be implemented to return metadata about the
-    // helper function.
+    // Once the fuzzer supports helper functions, this function should be
+    // implemented to return metadata about the helper function. Until then,
+    // throw to match the "not implemented" contract used by the sibling
+    // stubs in this file. Returning a default-constructed
+    // EbpfHelperPrototype{} would expose its null .name to the verifier,
+    // which may assign it to a std::string. PREVAIL is null-tolerant after
+    // commit 6f0384e3 ("Only Use Result From get_helper_prototype when
+    // valid"), but throwing is the correct contract for a not-implemented
+    // stub.
     UNREFERENCED_PARAMETER(n);
-    return {};
+    throw std::runtime_error("get_helper_prototype not implemented");
 }
 
 /**

--- a/libfuzzer/libfuzz_harness.cc
+++ b/libfuzzer/libfuzz_harness.cc
@@ -175,17 +175,10 @@ ubpf_get_map_type(uint32_t platform_specific_type)
 prevail::EbpfHelperPrototype
 ubpf_get_helper_prototype(int32_t n)
 {
-    // Once the fuzzer supports helper functions, this function should be
-    // implemented to return metadata about the helper function. Until then,
-    // throw to match the "not implemented" contract used by the sibling
-    // stubs in this file. Returning a default-constructed
-    // EbpfHelperPrototype{} would expose its null .name to the verifier,
-    // which may assign it to a std::string. PREVAIL is null-tolerant after
-    // commit 6f0384e3 ("Only Use Result From get_helper_prototype when
-    // valid"), but throwing is the correct contract for a not-implemented
-    // stub.
-    UNREFERENCED_PARAMETER(n);
-    throw std::runtime_error("get_helper_prototype not implemented");
+    // Not implemented — throw to match the sibling stubs in this file.
+    // Returning a default EbpfHelperPrototype{} would expose a null .name
+    // to the verifier.
+    throw std::runtime_error("get_helper_prototype not implemented (helper_id=" + std::to_string(n) + ")");
 }
 
 /**


### PR DESCRIPTION
Fixes #795.

The fuzzer's `ubpf_get_helper_prototype` stub returned a
default-constructed `EbpfHelperPrototype{}` whose `.name` is a null
pointer. Verifier paths that assigned `.name` to a `std::string` then
dereferenced NULL.

Throw `std::runtime_error("get_helper_prototype not implemented")`
instead, matching the "not implemented" contract already used by the
sibling stubs in this file (`ubpf_parse_maps_section`,
`ubpf_resolve_inner_map_references`, `ubpf_get_map_descriptor`).

PREVAIL has been null-tolerant since vbpf/prevail commit
[`6f0384e3`](https://github.com/vbpf/prevail/commit/6f0384e329649315cb05817c852dbe92bb239a2e)
("Only Use Result From get_helper_prototype when valid"), but throwing
is the correct contract for a stub that does not implement helper
functions.

## Reproduction

Build the fuzzer with `cmake -S . -B build -DUBPF_ENABLE_TESTS=true && cmake --build build --config Debug`, then run `ubpf_fuzzer` on an input containing an eBPF CALL-class instruction with `imm` referring to any helper id. Before this change the process crashes inside the verifier's `unmarshal` step; with this change verification proceeds.

## Test

Standard CMake build passes. This change only modifies the body of a single stub function whose siblings already throw with the same pattern.

---

Companion downstream PR: [microsoft/ebpf-for-windows#5374](https://github.com/microsoft/ebpf-for-windows/pull/5374).