### PR TITLE
build: make Windows builds compatible with both VS2022 and VS2026

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -176,7 +176,9 @@ jobs:
       shell: cmd
       run: |
         call "${{ steps.vs.outputs.path }}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=amd64
+        for /f "delims=" %%i in ('clang-cl --print-resource-dir') do set "CLANG_RESOURCE_DIR=%%i"
         copy "%VCToolsInstallDir%\bin\hostx64\x64\clang*" build\bin
+        copy "%CLANG_RESOURCE_DIR%\lib\windows\clang_rt.asan_dynamic-x86_64.dll" build\bin
         for /d %%d in ("%VCToolsRedistDir%\x64\Microsoft.VC*.CRT") do copy "%%d\*" build\bin
         dir build\bin
 
@@ -185,7 +187,7 @@ jobs:
       with:
         name: fuzzer-${{ matrix.platform }}-${{ matrix.arch }}
         path: |
-          build/bin
+          build/bin/*
 
   run_fuzzer:
     needs:
@@ -278,4 +280,3 @@ jobs:
       with:
         name: fuzzing-artifacts-${{ matrix.platform }}-${{ matrix.arch }}
         path: artifacts/
-

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -146,33 +146,46 @@ jobs:
         path: build
         key: ${{ matrix.platform }}-${{ matrix.arch }}-${{ hashFiles('**/CMakeLists.txt') }}
 
-    - name: Configure uBPF
+    - name: Find Visual Studio with vswhere
+      id: vs
+      shell: pwsh
       run: |
+        $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" `
+          -latest -property installationPath -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+        if (-not $vsPath) { throw "No Visual Studio installation found" }
+        echo "path=$vsPath" >> $env:GITHUB_OUTPUT
+        echo "Found Visual Studio at: $vsPath"
+
+    - name: Configure uBPF
+      shell: cmd
+      run: |
+        call "${{ steps.vs.outputs.path }}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=amd64
         cmake --preset fuzzing-windows
 
     - name: Build uBPF
+      shell: cmd
       run: |
-        cmake --build build --config RelWithDebInfo
+        call "${{ steps.vs.outputs.path }}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=amd64
+        cmake --build build
 
     - name: Generate dictionary
       run: |
-        python ubpf\dictionary_generator.py >build\bin\RelWithDebInfo\dictionary.txt
+        python ubpf\dictionary_generator.py >build\bin\dictionary.txt
 
     - name: Gather dependencies
       shell: cmd
       run: |
-        dir "C:\Program Files\Microsoft Visual Studio\2022"
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
-        copy "%VCToolsInstallDir%"\bin\hostx64\x64\clang* build\bin\RelWithDebInfo
-        copy "%VCToolsRedistDir%\x64\Microsoft.VC143.CRT" build\bin\RelWithDebInfo
-        dir build\bin\RelWithDebInfo
+        call "${{ steps.vs.outputs.path }}\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=amd64
+        copy "%VCToolsInstallDir%\bin\hostx64\x64\clang*" build\bin
+        for /d %%d in ("%VCToolsRedistDir%\x64\Microsoft.VC*.CRT") do copy "%%d\*" build\bin
+        dir build\bin
 
     - name: Upload fuzzer as artifacts
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: fuzzer-${{ matrix.platform }}-${{ matrix.arch }}
         path: |
-          build/bin/RelWithDebInfo
+          build/bin
 
   run_fuzzer:
     needs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,11 +44,14 @@ endif()
 
 if (UBPF_ENABLE_LIBFUZZER)
   if (PLATFORM_WINDOWS)
-    # Set compiler flags for libfuzzer
-    # Note: /fsanitize-coverage=inline-bool-flag causes link failures on Windows (missing _SancovBoolFlagUsed)
+    # Set compiler flags for libfuzzer.
+    # Use -fsanitize/-fsanitize-coverage (dash prefix) for compatibility with both
+    # MSVC cl.exe and clang-cl. The slash-prefix form (/fsanitize-coverage=...) is not
+    # recognized by clang-cl and gets interpreted as a file path.
+    # Note: -fsanitize-coverage=inline-bool-flag causes link failures on Windows (missing _SancovBoolFlagUsed)
     # when building non-fuzzer executables like prevail's check.exe.
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /fsanitize=address /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fsanitize=address /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -fsanitize-coverage=edge -fsanitize-coverage=trace-cmp -fsanitize-coverage=trace-div")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fsanitize-coverage=edge -fsanitize-coverage=trace-cmp -fsanitize-coverage=trace-div")
 
     # Prevail adds a custom "FuzzerDebug" multi-config configuration on MSVC.
     # Ensure the corresponding CMake cache variables exist so generation succeeds.
@@ -61,13 +64,22 @@ if (UBPF_ENABLE_LIBFUZZER)
 
   # Prevail (and its bundled libbtf) enables LTO by default on Clang/GCC. In CI this can
   # fail due to LLVM toolchain version mismatches in the binutils LTO plugin, and our
-  # fuzzing build does not need LTO.
-  if(PLATFORM_LINUX OR PLATFORM_MACOS)
-    foreach(_tgt IN ITEMS prevail libbtf)
-      if(TARGET ${_tgt})
-        set_property(TARGET ${_tgt} PROPERTY INTERPROCEDURAL_OPTIMIZATION FALSE)
+  # fuzzing build does not need LTO. On Windows with clang-cl, -flto=auto and -g3 are
+  # unsupported GCC/Clang flags that get incorrectly applied because CMake identifies
+  # clang-cl as "Clang".
+  foreach(_tgt IN ITEMS prevail libbtf)
+    if(TARGET ${_tgt})
+      set_property(TARGET ${_tgt} PROPERTY INTERPROCEDURAL_OPTIMIZATION FALSE)
+      # Strip GCC/Clang-only flags that ebpf-verifier adds as compile options.
+      # These are invalid for clang-cl on Windows.
+      get_target_property(_opts ${_tgt} COMPILE_OPTIONS)
+      if(_opts)
+        list(FILTER _opts EXCLUDE REGEX "^-flto|^-g3$")
+        set_property(TARGET ${_tgt} PROPERTY COMPILE_OPTIONS "${_opts}")
+      endif()
+      if(PLATFORM_LINUX OR PLATFORM_MACOS)
         target_compile_options(${_tgt} PRIVATE -fno-lto)
       endif()
-    endforeach()
-  endif()
+    endif()
+  endforeach()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ if (UBPF_ENABLE_LIBFUZZER)
       # These are invalid for clang-cl on Windows.
       get_target_property(_opts ${_tgt} COMPILE_OPTIONS)
       if(_opts)
-        list(FILTER _opts EXCLUDE REGEX "^-flto|^-g3$")
+        list(FILTER _opts EXCLUDE REGEX "^-flto|^-g3$|^\\$<")
         set_property(TARGET ${_tgt} PROPERTY COMPILE_OPTIONS "${_opts}")
       endif()
       if(PLATFORM_LINUX OR PLATFORM_MACOS)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -48,8 +48,10 @@
       "description": "Build configuration for libFuzzer-based fuzzing on Windows",
       "inherits": "base",
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "MinSizeRel",
         "UBPF_ENABLE_TESTS": "OFF",
         "UBPF_ENABLE_LIBFUZZER": "ON",
+        "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<CONFIG:FuzzerDebug>:Debug>",
         "CMAKE_C_COMPILER": "clang-cl",
         "CMAKE_CXX_COMPILER": "clang-cl"
       },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -47,10 +47,11 @@
       "displayName": "Fuzzing Configuration (Windows)",
       "description": "Build configuration for libFuzzer-based fuzzing on Windows",
       "inherits": "base",
-      "generator": "Visual Studio 17 2022",
       "cacheVariables": {
         "UBPF_ENABLE_TESTS": "OFF",
-        "UBPF_ENABLE_LIBFUZZER": "ON"
+        "UBPF_ENABLE_LIBFUZZER": "ON",
+        "CMAKE_C_COMPILER": "clang-cl",
+        "CMAKE_CXX_COMPILER": "clang-cl"
       },
       "condition": {
         "type": "equals",
@@ -87,8 +88,7 @@
     },
     {
       "name": "fuzzing-windows",
-      "configurePreset": "fuzzing-windows",
-      "configuration": "RelWithDebInfo"
+      "configurePreset": "fuzzing-windows"
     },
     {
       "name": "all-testing",

--- a/cmake/settings.cmake
+++ b/cmake/settings.cmake
@@ -90,8 +90,6 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
         )
     endif()
   elseif(PLATFORM_WINDOWS)
-    set(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION "8.1")
-
     target_compile_options("ubpf_settings" INTERFACE
       /W4
     )

--- a/docs/specs/design.md
+++ b/docs/specs/design.md
@@ -1,7 +1,7 @@
 # uBPF Design Specification
 
 **Document Version:** 1.2.0
-**Date:** 2026-06-12
+**Date:** 2026-06-15
 **Status:** Draft — Refreshed from source and test inventory
 
 ---
@@ -888,20 +888,23 @@ OS services (mmap, RNG)    │  Control flow
 
 ### 7.1 Build System
 
-- **CMake 3.16+** with Ninja (preferred) or Visual Studio generators
+- **CMake 3.16+** with Ninja (preferred) or platform-default generators
 - **Presets:** `tests`, `fuzzing`, `fuzzing-windows`, `all-testing`
 - **Version:** 1.0.0 (defined in `cmake/version.cmake`)
+- **Visual Studio compatibility:** The build system MUST NOT hardcode a specific Visual Studio generator version. The `fuzzing-windows` preset uses Ninja with `clang-cl` to avoid VS version coupling. When consumers use the Visual Studio generator directly (e.g., `cmake -G "Visual Studio 17 2022"` or `cmake -G "Visual Studio 18 2026"`), the build MUST succeed with either. The Windows target platform SDK version MUST NOT be pinned to a version unavailable in newer VS releases.
 
 ### 7.2 CI/CD Pipeline
 
 7 GitHub Actions workflows providing:
-- Windows (Debug/Release, with/without retpolines)
+- Windows (Debug/Release, with/without retpolines) — pinned `windows-2022` runner for stability
 - Linux (Debug/Release, coverage, ASan/UBSan, Valgrind, scan-build, CodeQL)
 - macOS (Debug/Release)
 - ARM64 (cross-compilation + QEMU)
-- Fuzzing (1-hour daily, corpus regression)
+- Fuzzing (1-hour daily, corpus regression) — `windows-latest` runner with dynamic VS discovery
 - Documentation (Doxygen → gh-pages)
 - Security (dependency review, OSSF Scorecard)
+
+CI workflows on Windows MUST dynamically locate the Visual Studio installation and CRT redistributables using `vswhere` or environment variables set by `VsDevCmd.bat`, rather than hardcoding version-specific filesystem paths.
 
 ### 7.3 Packaging
 
@@ -931,5 +934,6 @@ OS services (mmap, RNG)    │  Control flow
 
 | Version | Date | Author | Description |
 |---------|------|--------|-------------|
+| 1.2.0 | 2026-06-15 | Evolve | Updated build system and CI/CD design to require VS-version-agnostic configuration (REQ-PLAT-007). Fuzzing-windows preset migrated to Ninja+clang-cl; CI uses dynamic VS discovery. |
 | 1.1.0 | 2026-06-12 | Bootstrap refresh | Added explicit design traceability for ISA execution semantics, security callback coverage, configuration/error-handling design, and constants/limits. |
 | 1.0.0 | 2026-03-31 | Extracted by AI | Initial draft — extracted from uBPF source code analysis |

--- a/docs/specs/requirements.md
+++ b/docs/specs/requirements.md
@@ -1,7 +1,7 @@
 # uBPF Requirements Specification
 
 **Document Version:** 1.2.0
-**Date:** 2026-06-12
+**Date:** 2026-06-15
 **Status:** Draft — Refreshed from source and test inventory
 
 ---
@@ -1030,6 +1030,18 @@ uBPF MUST compile and run on Windows with MSVC. Platform compatibility MUST be p
   - AC-2: `mmap`/`mprotect` emulation provides equivalent W⊕X semantics.
   - AC-3: Interpreter atomic operations function correctly on Windows.
 
+#### REQ-PLAT-007: Visual Studio Version Compatibility
+
+uBPF MUST build successfully with Visual Studio 2022 (v17, toolset v143) and Visual Studio 2026 (v18+, toolset v144+). The build system MUST NOT hardcode a specific Visual Studio generator version or Windows SDK version that restricts compatibility to a single VS release.
+
+- **Source:** `CMakePresets.json`, `cmake/settings.cmake:93`, `.github/workflows/fuzzing.yml:164-167`
+- **Confidence:** **High**
+- **Acceptance Criteria:**
+  - AC-1: `cmake --preset fuzzing-windows` succeeds on a system with only VS2022 installed.
+  - AC-2: `cmake --preset fuzzing-windows` succeeds on a system with only VS2026 installed.
+  - AC-3: The default CMake configuration (`cmake -S . -B build`) succeeds with either VS version without specifying a generator.
+  - AC-4: CI workflows dynamically discover the VS installation path and CRT redistributables rather than hardcoding version-specific paths.
+
 #### REQ-PLAT-002: Linux Support
 
 uBPF MUST compile and run on Linux with GCC or Clang. Linux-specific dependencies:
@@ -1426,5 +1438,6 @@ The JIT compiler generates native code without formal verification of equivalenc
 
 | Version | Date | Author | Description |
 |---------|------|--------|-------------|
+| 1.2.0 | 2026-06-15 | Evolve | Added REQ-PLAT-007 (Visual Studio version compatibility) requiring the build to work with both VS2022 and VS2026 without hardcoding generator or SDK versions. |
 | 1.1.0 | 2026-06-12 | Bootstrap refresh | Refined ISA and configuration requirements to match current validator and interpreter behavior, clarified partial ARM64 constant blinding, corrected register-access API signatures, realigned ARM64 JIT requirements with actual backend scope, and tightened runtime error-reporting language. |
 | 1.0.0 | 2026-03-31 | Extracted from source | Initial requirements extraction from uBPF codebase. All requirements derived from source code analysis of the public API (`vm/inc/ubpf.h`), VM implementation (`vm/ubpf_vm.c`), instruction validator (`vm/ubpf_instruction_valid.c`), ELF loader (`vm/ubpf_loader.c`), JIT compilers (`vm/ubpf_jit_x86_64.c`, `vm/ubpf_jit_arm64.c`, `vm/ubpf_jit.c`), internal headers (`vm/ubpf_int.h`, `vm/ebpf.h`), and build configuration (`CMakeLists.txt`, `cmake/`). |

--- a/docs/specs/validation.md
+++ b/docs/specs/validation.md
@@ -1,7 +1,7 @@
 # uBPF Validation Plan
 
-**Document Version:** 1.2.0
-**Date:** 2026-06-12
+**Document Version:** 1.3.0
+**Date:** 2026-06-15
 **Status:** Draft — Refreshed from current test inventory
 
 ---
@@ -932,12 +932,23 @@ uBPF uses a multi-layered testing strategy:
 ### TC-PLAT — Platform Support
 
 #### TC-PLAT-001: Windows Support
-- **Traces to:** REQ-PLAT-001
+- **Traces to:** REQ-PLAT-001, REQ-PLAT-007
 - **Level:** System
 - **Confidence:** High
-- **Evidence:** CI: windows-2022, Debug + Release configurations
-- **Pass criteria:** All tests pass on Windows with MSVC
-- **Existing tests:** CI matrix (windows-2022)
+- **Evidence:** CI: windows-2022, Debug + Release configurations; fuzzing: windows-latest with dynamic VS discovery
+- **Pass criteria:** All tests pass on Windows with MSVC; build succeeds with both VS2022 and VS2026
+- **Existing tests:** CI matrix (windows-2022), fuzzing workflow (windows-latest)
+
+#### TC-PLAT-009: Visual Studio Version Compatibility
+- **Traces to:** REQ-PLAT-007
+- **Level:** System
+- **Confidence:** High
+- **Evidence:** `CMakePresets.json` (fuzzing-windows preset uses Ninja, no hardcoded VS generator), `cmake/settings.cmake` (no pinned SDK version), `.github/workflows/fuzzing.yml` (dynamic VS path discovery via vswhere)
+- **Pass criteria:**
+  - The `fuzzing-windows` CMake preset configures successfully on both VS2022 and VS2026 environments
+  - The CI fuzzing workflow builds and runs on `windows-latest` regardless of installed VS version
+  - No hardcoded VS2022-specific paths remain in workflow files or CMake presets
+- **Existing tests:** CI fuzzing workflow on windows-latest
 
 #### TC-PLAT-002: Linux Support
 - **Traces to:** REQ-PLAT-002
@@ -1208,6 +1219,7 @@ Test suite passes when:
 
 | Version | Date | Author | Description |
 |---------|------|--------|-------------|
+| 1.3.0 | 2026-06-15 | Evolve | Added TC-PLAT-009 for Visual Studio version compatibility validation (REQ-PLAT-007). Updated TC-PLAT-001 to trace to new requirement. |
 | 1.2.0 | 2026-06-12 | Evolve refresh | Added validation scope for the additive safe-interpreter profile, including planned coverage for provenance enforcement and safe-mode JIT rejection. |
 | 1.1.0 | 2026-06-12 | Bootstrap refresh | Reconciled current test inventory counts, credited indirect `ubpf_copy_jit()` coverage via `ubpf_plugin`, and downgraded overstated RNG coverage claims. |
 | 1.0.0 | 2026-03-31 | Extracted by AI | Initial draft — mapped existing tests to requirements, identified gaps |

--- a/libfuzzer/CMakeLists.txt
+++ b/libfuzzer/CMakeLists.txt
@@ -49,8 +49,19 @@ add_executable(
 target_include_directories("ubpf_fuzzer" PRIVATE ${UBPF_FUZZER_INCLUDES})
 
 if (PLATFORM_WINDOWS)
+  execute_process(
+    COMMAND "${CMAKE_CXX_COMPILER}" --print-resource-dir
+    OUTPUT_VARIABLE CLANG_RESOURCE_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  set(CLANG_RT_DIR "${CLANG_RESOURCE_DIR}/lib/windows")
   set(CMAKE_EXE_LINKER_FLAGS_FUZZERDEBUG libsancov.lib clang_rt.fuzzer_MDd-x86_64.lib)
+  target_link_libraries(ubpf_fuzzer PRIVATE
+    "${CLANG_RT_DIR}/clang_rt.fuzzer-x86_64.lib"
+    "${CLANG_RT_DIR}/clang_rt.asan_dynamic_runtime_thunk-x86_64.lib"
+    "${CLANG_RT_DIR}/clang_rt.asan_dynamic-x86_64.lib")
+else()
+  target_link_libraries(ubpf_fuzzer PRIVATE "-fsanitize=fuzzer")
 endif()
 
-target_link_libraries(ubpf_fuzzer PRIVATE "-fsanitize=fuzzer")
 target_link_libraries(ubpf_fuzzer PRIVATE ${UBPF_FUZZER_LIBS})


### PR DESCRIPTION
## Summary

Fixes the CI fuzzing workflow failure on \windows-latest\ runners that have migrated from VS2022 to VS2026, and ensures library consumers can build with either VS version.

## Changes

- **CMakePresets.json** — Replace hardcoded \Visual Studio 17 2022\ generator with Ninja + clang-cl (VS-version-agnostic)
- **cmake/settings.cmake** — Remove hardcoded \CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION 8.1\ pin
- **.github/workflows/fuzzing.yml** — Dynamic VS discovery via \swhere\; wildcard for VC CRT redistributables
- **CMakeLists.txt** — Fix sanitize coverage flags (\/\ → \-\ prefix for clang-cl); strip \-flto=auto\ and \-g3\ from ebpf-verifier targets on Windows
- **Spec updates** — Added REQ-PLAT-007, updated design §7.1/7.2, added TC-PLAT-009

## Testing

- \cmake --preset fuzzing-windows\ configures successfully with VS2026 (Ninja + clang-cl)
- \cmake -S . -B build -DUBPF_ENABLE_TESTS=true\ auto-detects VS 18 and builds
- 1272/1276 tests pass (4 pre-existing BPF ELF test failures unrelated to this change)

## Related

https://github.com/iovisor/ubpf/actions/runs/27512496755