### PR TITLE
Alanjo/vs2026 cmake

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -138,11 +138,14 @@ jobs:
       with:
         submodules: 'recursive'
 
-    - name: Detect Visual Studio version
-      id: vs_version
+    - name: Select Visual Studio preset
+      id: vs_preset
       shell: pwsh
       run: |
-        "major=$(& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property catalog_productLineVersion)" >> $env:GITHUB_OUTPUT
+        $major = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property catalog_productLineVersion
+        $preset = if ($major -eq "18") { "fuzzing-windows-vs2026" } else { "fuzzing-windows" }
+        "major=$major" >> $env:GITHUB_OUTPUT
+        "preset=$preset" >> $env:GITHUB_OUTPUT
 
     - name: Cache the build folder
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
@@ -150,11 +153,11 @@ jobs:
         cache-name: cache-nuget-modules
       with:
         path: build
-        key: ${{ matrix.platform }}-${{ matrix.arch }}-vs${{ steps.vs_version.outputs.major }}-${{ hashFiles('**/CMakeLists.txt') }}
+        key: ${{ matrix.platform }}-${{ matrix.arch }}-vs${{ steps.vs_preset.outputs.major }}-${{ hashFiles('**/CMakeLists.txt', 'CMakePresets.json') }}
 
     - name: Configure uBPF
       run: |
-        cmake --preset fuzzing-windows
+        cmake --preset ${{ steps.vs_preset.outputs.preset }}
 
     - name: Build uBPF
       run: |

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -138,13 +138,19 @@ jobs:
       with:
         submodules: 'recursive'
 
+    - name: Detect Visual Studio version
+      id: vs_version
+      shell: pwsh
+      run: |
+        "major=$(& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property catalog_productLineVersion)" >> $env:GITHUB_OUTPUT
+
     - name: Cache the build folder
       uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
       env:
         cache-name: cache-nuget-modules
       with:
         path: build
-        key: ${{ matrix.platform }}-${{ matrix.arch }}-${{ hashFiles('**/CMakeLists.txt') }}
+        key: ${{ matrix.platform }}-${{ matrix.arch }}-vs${{ steps.vs_version.outputs.major }}-${{ hashFiles('**/CMakeLists.txt') }}
 
     - name: Configure uBPF
       run: |
@@ -265,4 +271,3 @@ jobs:
       with:
         name: fuzzing-artifacts-${{ matrix.platform }}-${{ matrix.arch }}
         path: artifacts/
-

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -142,7 +142,8 @@ jobs:
       id: vs_preset
       shell: pwsh
       run: |
-        $major = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property catalog_productLineVersion
+        $versionRaw = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property catalog_productLineVersion
+        $major = $versionRaw.Trim().Split('.')[0]
         $preset = if ($major -eq "18") { "fuzzing-windows-vs2026" } else { "fuzzing-windows" }
         "major=$major" >> $env:GITHUB_OUTPUT
         "preset=$preset" >> $env:GITHUB_OUTPUT
@@ -171,8 +172,8 @@ jobs:
       shell: pwsh
       run: |
         $vs_install_dir = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-        Copy-Item "$vs_install_dir\VC\Tools\MSVC\*\bin\Hostx64\x64\clang_rt.asan*x86_64.dll" build\bin\RelWithDebInfo
-        Copy-Item "$vs_install_dir\VC\Redist\MSVC\*\x64\Microsoft.VC*.CRT\*.dll" build\bin\RelWithDebInfo
+        Copy-Item "$vs_install_dir\VC\Tools\MSVC\*\bin\Hostx64\x64\clang_rt.asan*x86_64.dll" build\bin\RelWithDebInfo -Force
+        Copy-Item "$vs_install_dir\VC\Redist\MSVC\*\x64\Microsoft.VC*.CRT\*.dll" build\bin\RelWithDebInfo -Force
         Get-ChildItem build\bin\RelWithDebInfo
 
     - name: Upload fuzzer as artifacts

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -173,7 +173,7 @@ jobs:
         for /f "usebackq delims=" %%I in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do set "VSINSTALLDIR=%%I"
         call "%VSINSTALLDIR%\Common7\Tools\VsDevCmd.bat"
         copy "%VCToolsInstallDir%"\bin\hostx64\x64\clang* build\bin\RelWithDebInfo
-        copy "%VCToolsRedistDir%\x64\Microsoft.VC143.CRT\*" build\bin\RelWithDebInfo
+        for /d %%I in ("%VCToolsRedistDir%\x64\Microsoft.VC*.CRT") do copy "%%~fI\*" build\bin\RelWithDebInfo
         dir build\bin\RelWithDebInfo
 
     - name: Upload fuzzer as artifacts

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -170,10 +170,10 @@ jobs:
     - name: Gather dependencies
       shell: cmd
       run: |
-        dir "C:\Program Files\Microsoft Visual Studio\2022"
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
+        for /f "usebackq delims=" %%I in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do set "VSINSTALLDIR=%%I"
+        call "%VSINSTALLDIR%\Common7\Tools\VsDevCmd.bat"
         copy "%VCToolsInstallDir%"\bin\hostx64\x64\clang* build\bin\RelWithDebInfo
-        copy "%VCToolsRedistDir%\x64\Microsoft.VC143.CRT" build\bin\RelWithDebInfo
+        copy "%VCToolsRedistDir%\x64\Microsoft.VC143.CRT\*" build\bin\RelWithDebInfo
         dir build\bin\RelWithDebInfo
 
     - name: Upload fuzzer as artifacts

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -168,13 +168,12 @@ jobs:
         python ubpf\dictionary_generator.py >build\bin\RelWithDebInfo\dictionary.txt
 
     - name: Gather dependencies
-      shell: cmd
+      shell: pwsh
       run: |
-        for /f "usebackq delims=" %%I in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do set "VSINSTALLDIR=%%I"
-        call "%VSINSTALLDIR%\Common7\Tools\VsDevCmd.bat"
-        copy "%VCToolsInstallDir%"\bin\hostx64\x64\clang* build\bin\RelWithDebInfo
-        for /d %%I in ("%VCToolsRedistDir%\x64\Microsoft.VC*.CRT") do copy "%%~fI\*" build\bin\RelWithDebInfo
-        dir build\bin\RelWithDebInfo
+        $vs_install_dir = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+        Copy-Item "$vs_install_dir\VC\Tools\MSVC\*\bin\Hostx64\x64\clang_rt.asan*x86_64.dll" build\bin\RelWithDebInfo
+        Copy-Item "$vs_install_dir\VC\Redist\MSVC\*\x64\Microsoft.VC*.CRT\*.dll" build\bin\RelWithDebInfo
+        Get-ChildItem build\bin\RelWithDebInfo
 
     - name: Upload fuzzer as artifacts
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -107,6 +107,11 @@
       "configuration": "RelWithDebInfo"
     },
     {
+      "name": "fuzzing-windows-vs2026",
+      "configurePreset": "fuzzing-windows-vs2026",
+      "configuration": "RelWithDebInfo"
+    },
+    {
       "name": "all-testing",
       "configurePreset": "all-testing"
     }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -59,6 +59,22 @@
       }
     },
     {
+      "name": "fuzzing-windows-vs2026",
+      "displayName": "Fuzzing Configuration (Windows, VS 2026)",
+      "description": "Build configuration for libFuzzer-based fuzzing on Windows with Visual Studio 2026",
+      "inherits": "base",
+      "generator": "Visual Studio 18 2026",
+      "cacheVariables": {
+        "UBPF_ENABLE_TESTS": "OFF",
+        "UBPF_ENABLE_LIBFUZZER": "ON"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
       "name": "all-testing",
       "displayName": "All Testing Configuration",
       "description": "Build configuration for both tests and fuzzing",


### PR DESCRIPTION
This pull request updates the `.github/workflows/fuzzing.yml` workflow to improve build caching by detecting and including the Visual Studio version in the cache key. This ensures that the cache is properly invalidated when the Visual Studio version changes, preventing potential build issues.

**Build caching improvements:**

* Added a step to detect the installed Visual Studio version using `vswhere.exe` and output its major version to the workflow (`.github/workflows/fuzzing.yml`).
* Updated the build cache key to include the detected Visual Studio version, improving cache accuracy across different environments (`.github/workflows/fuzzing.yml`).