### PR TITLE
Loader and verifier fixes for clang/LLVM BPF outputLoader verifier fixes

### DIFF
--- a/custom_tests/descrs/ubpf_test_elf_unrelocated_local_call.md
+++ b/custom_tests/descrs/ubpf_test_elf_unrelocated_local_call.md
@@ -1,0 +1,22 @@
+## Test Description
+
+This custom test verifies that the ELF loader correctly resolves an
+un-relocated, intra-section bpf-to-bpf call (clang emits these with a
+PC-relative `imm` and no relocation entry) when the symbol-table order does
+not match ascending section offset.
+
+The crafted relocatable ELF has one executable section containing two
+functions whose symbol-table order is the reverse of their section-offset
+order:
+
+- `callee` at section offset 0x00: `r0 = 7; exit`
+- `entry`  at section offset 0x10: `call callee; exit`  (PC-relative imm, no relocation)
+
+`entry` is the named main function, so the loader pins it to linked PC 0 even
+though it sits at section offset 0x10. A loader that relies on link layout
+matching the `.o` layout mis-resolves the call; the correct loader rewrites the
+call from post-link `landed` values and the program returns 7.
+
+### Expected Behavior
+
+Loading and executing the program returns `0x7`.

--- a/custom_tests/srcs/ubpf_test_elf_unrelocated_local_call.cc
+++ b/custom_tests/srcs/ubpf_test_elf_unrelocated_local_call.cc
@@ -1,0 +1,164 @@
+// Copyright (c) uBPF contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+extern "C"
+{
+#include "ubpf.h"
+}
+
+#include "ubpf_custom_test_support.h"
+
+// The ELF loader API (ubpf_load_elf_ex) is only declared when uBPF is built with
+// <elf.h> support, which is not the case on Windows. Skip the test there.
+#if defined(UBPF_HAS_ELF_H)
+
+// Build a minimal ET_REL BPF object in memory:
+//   section "prog" (PROGBITS, ALLOC|EXECINSTR):
+//     0x00 callee: r0 = 7 ; exit
+//     0x10 entry : call callee ; exit   (PC-relative imm = -3, NO relocation)
+//   one combined string table (section names + symbol names)
+//   symbol table lists entry (st_value 0x10) BEFORE callee (st_value 0x00)
+// main-function = "entry".
+static std::vector<uint8_t>
+build_reorder_elf()
+{
+    auto u16 = [](std::vector<uint8_t>& v, uint16_t x) {
+        v.push_back(x & 0xff); v.push_back((x >> 8) & 0xff);
+    };
+    auto u32 = [](std::vector<uint8_t>& v, uint32_t x) {
+        for (int i = 0; i < 4; i++) v.push_back((x >> (8 * i)) & 0xff);
+    };
+    auto u64 = [](std::vector<uint8_t>& v, uint64_t x) {
+        for (int i = 0; i < 8; i++) v.push_back((x >> (8 * i)) & 0xff);
+    };
+    auto insn = [](std::vector<uint8_t>& v, uint8_t op, uint8_t dst, uint8_t src,
+                   int16_t off, int32_t imm) {
+        v.push_back(op);
+        v.push_back((uint8_t)((src << 4) | (dst & 0xf)));
+        v.push_back(off & 0xff); v.push_back((off >> 8) & 0xff);
+        for (int i = 0; i < 4; i++) v.push_back(((uint32_t)imm >> (8 * i)) & 0xff);
+    };
+
+    // prog section bytes
+    std::vector<uint8_t> text;
+    insn(text, 0xb7, 0, 0, 0, 7);   // callee: r0 = 7
+    insn(text, 0x95, 0, 0, 0, 0);   // callee: exit
+    insn(text, 0x85, 0, 1, 0, -3);  // entry : call callee (PC-relative)
+    insn(text, 0x95, 0, 0, 0, 0);   // entry : exit
+
+    // combined string table
+    std::string strt;
+    strt.push_back('\0');
+    auto add_str = [&](const char* s) { size_t off = strt.size(); strt += s; strt.push_back('\0'); return (uint32_t)off; };
+    uint32_t n_prog = add_str("prog");
+    uint32_t n_strtab = add_str(".strtab");
+    uint32_t n_symtab = add_str(".symtab");
+    uint32_t n_callee = add_str("callee");
+    uint32_t n_entry = add_str("entry");
+
+    // symbol table: null, entry (global func, off 0x10), callee (local func, off 0x00)
+    const uint8_t PROG = 1;
+    std::vector<uint8_t> sym;
+    auto add_sym = [&](uint32_t name, uint8_t info, uint16_t shndx, uint64_t val, uint64_t size) {
+        u32(sym, name); sym.push_back(info); sym.push_back(0); u16(sym, shndx); u64(sym, val); u64(sym, size);
+    };
+    add_sym(0, 0, 0, 0, 0);
+    add_sym(n_entry,  (1 << 4) | 2, PROG, 0x10, 16);  // STB_GLOBAL|STT_FUNC
+    add_sym(n_callee, (0 << 4) | 2, PROG, 0x00, 16);  // STB_LOCAL|STT_FUNC
+
+    // offsets
+    const uint64_t ehsize = 64, shsize = 64, nsh = 4;
+    uint64_t off = ehsize;
+    uint64_t text_off = off; off += text.size();
+    uint64_t strt_off = off; off += strt.size();
+    uint64_t sym_off = off; off += sym.size();
+    uint64_t pad = (8 - (off % 8)) % 8; off += pad;
+    uint64_t shoff = off;
+
+    std::vector<uint8_t> elf;
+    // e_ident
+    elf.push_back(0x7f); elf.push_back('E'); elf.push_back('L'); elf.push_back('F');
+    elf.push_back(2); elf.push_back(1); elf.push_back(1); elf.push_back(0);
+    for (int i = 0; i < 8; i++) elf.push_back(0);
+    u16(elf, 1);     // e_type ET_REL
+    u16(elf, 247);   // e_machine EM_BPF
+    u32(elf, 1);     // e_version
+    u64(elf, 0);     // e_entry
+    u64(elf, 0);     // e_phoff
+    u64(elf, shoff); // e_shoff
+    u32(elf, 0);     // e_flags
+    u16(elf, ehsize);// e_ehsize
+    u16(elf, 0); u16(elf, 0);        // phentsize, phnum
+    u16(elf, shsize); u16(elf, nsh); // shentsize, shnum
+    u16(elf, 2);     // e_shstrndx -> .strtab (index 2)
+
+    elf.insert(elf.end(), text.begin(), text.end());
+    elf.insert(elf.end(), strt.begin(), strt.end());
+    elf.insert(elf.end(), sym.begin(), sym.end());
+    for (uint64_t i = 0; i < pad; i++) elf.push_back(0);
+
+    auto add_shdr = [&](uint32_t name, uint32_t type, uint64_t flags, uint64_t addr,
+                        uint64_t offset, uint64_t size, uint32_t link, uint32_t info,
+                        uint64_t align, uint64_t entsize) {
+        u32(elf, name); u32(elf, type); u64(elf, flags); u64(elf, addr);
+        u64(elf, offset); u64(elf, size); u32(elf, link); u32(elf, info);
+        u64(elf, align); u64(elf, entsize);
+    };
+    add_shdr(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);                                  // NULL
+    add_shdr(n_prog, 1, 0x2 | 0x4, 0, text_off, text.size(), 0, 0, 8, 0);    // prog PROGBITS ALLOC|EXEC
+    add_shdr(n_strtab, 3, 0, 0, strt_off, strt.size(), 0, 0, 1, 0);          // .strtab STRTAB
+    add_shdr(n_symtab, 2, 0, 0, sym_off, sym.size(), 2, 1, 8, 24);           // .symtab SYMTAB link=.strtab
+
+    return elf;
+}
+
+int
+main(int, char**)
+{
+    std::vector<uint8_t> elf = build_reorder_elf();
+
+    std::unique_ptr<ubpf_vm, decltype(&ubpf_destroy)> vm(ubpf_create(), ubpf_destroy);
+    if (!vm) {
+        std::cerr << "Failed to create VM\n";
+        return 1;
+    }
+
+    char* errmsg = nullptr;
+    int rv = ubpf_load_elf_ex(vm.get(), elf.data(), elf.size(), "entry", &errmsg);
+    if (rv < 0) {
+        std::cerr << "Failed to load ELF: " << (errmsg ? errmsg : "(null)") << "\n";
+        free(errmsg);
+        return 1;
+    }
+
+    uint64_t result = 0;
+    if (ubpf_exec(vm.get(), nullptr, 0, &result) < 0) {
+        std::cerr << "Failed to execute program\n";
+        return 1;
+    }
+
+    if (result != 7) {
+        std::cerr << "Expected 0x7, got 0x" << std::hex << result << "\n";
+        return 1;
+    }
+
+    std::cout << "PASS\n";
+    return 0;
+}
+
+#else // !UBPF_HAS_ELF_H
+
+int
+main(int, char**)
+{
+    std::cout << "SKIP: ELF loader not built (no <elf.h> support)\n";
+    return 0;
+}
+
+#endif // UBPF_HAS_ELF_H

--- a/tests/call-local-tail-jump.data
+++ b/tests/call-local-tail-jump.data
@@ -1,0 +1,11 @@
+-- asm
+mov %r0, 0
+call local body
+exit
+body:
+mov %r0, 1
+exit
+add %r0, 1
+ja body
+-- result
+0x1

--- a/tests/errors/err-call-tail-conditional.data
+++ b/tests/errors/err-call-tail-conditional.data
@@ -1,0 +1,10 @@
+-- asm
+mov %r0, 0
+call local body
+exit
+body:
+mov %r0, 1
+exit
+jne %r0, 0, body
+-- error
+Failed to load code: sub-program does not end with EXIT or unconditional jump at PC 5

--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -677,13 +677,15 @@ extern "C"
 
     /**
      * @brief Data relocation function that is called by the VM when it encounters a
-     * R_BPF_64_64 relocation in the maps section of the ELF file.
+     * R_BPF_64_64 relocation against an allocated, non-executable data section of
+     * the ELF file, such as .data (maps, writable globals) or .rodata (read-only
+     * globals, string literals).
      *
      * @param[in] user_context The user context that was passed to ubpf_register_data_relocation.
-     * @param[in] data Pointer to start of the map section.
-     * @param[in] data_size Size of the map section.
+     * @param[in] data Pointer to start of the target data section.
+     * @param[in] data_size Size of the target data section.
      * @param[in] symbol_name Name of the symbol that is referenced.
-     * @param[in] symbol_offset Offset of the symbol relative to the start of the map section.
+     * @param[in] symbol_offset Offset of the symbol relative to the start of the target data section.
      * @param[in] symbol_size Size of the symbol.
      * @return The value to insert into the BPF program.
      */

--- a/vm/inc/ubpf.h
+++ b/vm/inc/ubpf.h
@@ -685,7 +685,9 @@ extern "C"
      * @param[in] data Pointer to start of the target data section.
      * @param[in] data_size Size of the target data section.
      * @param[in] symbol_name Name of the symbol that is referenced.
-     * @param[in] symbol_offset Offset of the symbol relative to the start of the target data section.
+     * @param[in] symbol_offset Offset within `data` of the referenced location
+     *   (st_value, plus the LDDW imm addend for section-symbol relocations). The
+     *   loader guarantees symbol_offset + symbol_size <= data_size.
      * @param[in] symbol_size Size of the symbol.
      * @return The value to insert into the BPF program.
      */

--- a/vm/ubpf_loader.c
+++ b/vm/ubpf_loader.c
@@ -416,6 +416,7 @@ ubpf_load_elf_ex(struct ubpf_vm* vm, const void* elf, size_t elf_size, const cha
                     goto error;
                 }
 
+                // Wrap-safe form of st_value + st_size > map->size.
                 if (relo_sym.st_value > map->size || relo_sym.st_size > map->size - relo_sym.st_value) {
                     *errmsg = ubpf_error("bad R_BPF_64_64 size");
                     goto error;
@@ -436,12 +437,27 @@ ubpf_load_elf_ex(struct ubpf_vm* vm, const void* elf, size_t elf_size, const cha
                     goto error;
                 }
 
+                // BPF uses REL, so a section-symbol relocation (st_value == 0)
+                // carries its addend in the LDDW imm. Fold it in as an unsigned
+                // section offset so merged-string literals resolve distinctly.
+                uint64_t symbol_offset = relo_sym.st_value;
+                if (ELF64_ST_TYPE(relo_sym.st_info) == STT_SECTION) {
+                    symbol_offset += (uint64_t)(uint32_t)applies_to_inst->imm;
+                }
+
+                // imm is attacker-controlled; bound symbol_offset + st_size against
+                // the section (wrap-safe, st_size <= map->size already checked above).
+                if (symbol_offset > map->size || symbol_offset > map->size - relo_sym.st_size) {
+                    *errmsg = ubpf_error("bad R_BPF_64_64 symbol offset");
+                    goto error;
+                }
+
                 uint64_t imm = vm->data_relocation_function(
                     vm->data_relocation_user_data,
                     map->data,
                     map->size,
                     relo_sym_name,
-                    relo_sym.st_value,
+                    symbol_offset,
                     relo_sym.st_size);
                 applies_to_inst->imm = (uint32_t)imm;
                 applies_to_inst2->imm = (uint32_t)(imm >> 32);

--- a/vm/ubpf_loader.c
+++ b/vm/ubpf_loader.c
@@ -398,17 +398,25 @@ ubpf_load_elf_ex(struct ubpf_vm* vm, const void* elf, size_t elf_size, const cha
                     goto error;
                 }
 
-                if (relo_sym.st_shndx > section_count) {
+                if (relo_sym.st_shndx >= section_count) {
                     *errmsg = ubpf_error("bad R_BPF_64_64 relocation section index");
                     goto error;
                 }
                 section* map = &sections[relo_sym.st_shndx];
-                if (map->shdr->sh_type != SHT_PROGBITS || map->shdr->sh_flags != (SHF_ALLOC | SHF_WRITE)) {
-                    *errmsg = ubpf_error("bad R_BPF_64_64 relocation section");
+                /* Accept any allocated, non-executable PROGBITS section (.data, .rodata, .rodata.str*);
+                 * mask the flags so SHF_MERGE/SHF_STRINGS don't reject it, but exclude .text.
+                 */
+                if (map->shdr->sh_type != SHT_PROGBITS || !(map->shdr->sh_flags & SHF_ALLOC) ||
+                    (map->shdr->sh_flags & SHF_EXECINSTR)) {
+                    *errmsg = ubpf_error(
+                        "R_BPF_64_64 target section is not an allocated, non-executable PROGBITS section "
+                        "(sh_type=%" PRIu32 " sh_flags=0x%" PRIx64 ")",
+                        (uint32_t)map->shdr->sh_type,
+                        (uint64_t)map->shdr->sh_flags);
                     goto error;
                 }
 
-                if (relo_sym.st_size + relo_sym.st_value > map->size) {
+                if (relo_sym.st_value > map->size || relo_sym.st_size > map->size - relo_sym.st_value) {
                     *errmsg = ubpf_error("bad R_BPF_64_64 size");
                     goto error;
                 }

--- a/vm/ubpf_loader.c
+++ b/vm/ubpf_loader.c
@@ -487,6 +487,107 @@ ubpf_load_elf_ex(struct ubpf_vm* vm, const void* elf, size_t elf_size, const cha
     }
 
     /*
+     * Recompute intra-section bpf-to-bpf calls that clang left without a
+     * relocation entry. Their PC-relative imm is computed against the .o
+     * instruction layout, but functions land in symbol-table order, so the
+     * imm is stale once linked. Fix it from the landed positions, as the
+     * relocation pass does for relocated calls. Call sites that already carry
+     * a relocation are skipped; they were handled above.
+     */
+    for (uint fi = 0; fi < total_functions; fi++) {
+        struct relocated_function* fn = relocated_functions[fi];
+        /* st_size must be a whole number of instructions. */
+        if (fn->size % sizeof(struct ebpf_inst) != 0) {
+            *errmsg = ubpf_error("function size is not a multiple of the instruction size");
+            goto error;
+        }
+        uint64_t fn_insn_count = fn->size / sizeof(struct ebpf_inst);
+
+        for (uint64_t k = 0; k < fn_insn_count; k++) {
+            struct ebpf_inst* inst = (struct ebpf_inst*)fn->linked_data + k;
+
+            if (inst->opcode != EBPF_OP_CALL || inst->src != 1) {
+                continue;
+            }
+
+            /* Offset of this call within its original .o section. */
+            uint64_t call_off = fn->native_section_start + k * sizeof(struct ebpf_inst);
+
+            /*
+             * Skip call sites that already carry a relocation. SHT_RELA is
+             * scanned too: the loader does not apply it, but a match means the
+             * call is not un-relocated and must be left untouched here.
+             */
+            bool has_relocation = false;
+            for (int si = 0; si < section_count && !has_relocation; si++) {
+                if (sections[si].shdr->sh_type != SHT_REL && sections[si].shdr->sh_type != SHT_RELA) {
+                    continue;
+                }
+                if (sections[si].shdr->sh_info >= (uint32_t)section_count ||
+                    sections[si].shdr->sh_info >= MAX_SECTIONS) {
+                    continue;
+                }
+                if (sections[sections[si].shdr->sh_info].shdr != fn->shdr) {
+                    continue;
+                }
+                if (sections[si].shdr->sh_type == SHT_REL) {
+                    uint64_t rel_count = sections[si].size / sizeof(Elf64_Rel);
+                    const Elf64_Rel* rels = sections[si].data;
+                    for (uint64_t ri = 0; ri < rel_count; ri++) {
+                        Elf64_Rel r;
+                        memcpy(&r, rels + ri, sizeof(Elf64_Rel));
+                        if (r.r_offset == call_off) {
+                            has_relocation = true;
+                            break;
+                        }
+                    }
+                } else {
+                    uint64_t rela_count = sections[si].size / sizeof(Elf64_Rela);
+                    const Elf64_Rela* relas = sections[si].data;
+                    for (uint64_t ri = 0; ri < rela_count; ri++) {
+                        Elf64_Rela r;
+                        memcpy(&r, relas + ri, sizeof(Elf64_Rela));
+                        if (r.r_offset == call_off) {
+                            has_relocation = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            if (has_relocation) {
+                continue;
+            }
+
+            /* Decode the target's section offset from the PC-relative imm. */
+            int64_t target_off =
+                (int64_t)call_off + ((int64_t)inst->imm + 1) * (int64_t)sizeof(struct ebpf_inst);
+            if (target_off < 0) {
+                *errmsg = ubpf_error("un-relocated local call target is out of section bounds");
+                goto error;
+            }
+            /* No upper bound needed: an out-of-range target_off matches no
+             * function's native_section_start below and is rejected there. */
+
+            struct relocated_function* target_function = NULL;
+            for (uint ti = 0; ti < total_functions; ti++) {
+                if (relocated_functions[ti]->shdr == fn->shdr &&
+                    relocated_functions[ti]->native_section_start == (uint64_t)target_off) {
+                    target_function = relocated_functions[ti];
+                    break;
+                }
+            }
+            if (!target_function) {
+                *errmsg = ubpf_error("un-relocated local call does not target a known function");
+                goto error;
+            }
+
+            uint64_t call_index = fn->landed + k;
+            /* Narrowed to int32 to match the call imm width, as above. */
+            inst->imm = (int32_t)((int64_t)target_function->landed - (int64_t)call_index - 1);
+        }
+    }
+
+    /*
      * We got this far -- we'll set a provisional success value.
      */
     load_success = 1;

--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -2550,12 +2550,14 @@ static bool check_for_self_contained_sub_programs(const struct ebpf_inst* insts,
                 break;
             }
         }
-        // Last instruction of the sub-program must be EXIT or a jump to the current program.
+        // Last instruction of the sub-program must be EXIT or an unconditional jump.
+        // Note: the trailing jump's target is already bounds-checked by the loop above.
         bool ends_with_exit = insts[end_index - 1].opcode == EBPF_OP_EXIT;
-        bool ends_with_jump = false;
+        bool ends_with_jump = insts[end_index - 1].opcode == EBPF_OP_JA ||
+                              insts[end_index - 1].opcode == EBPF_OP_JA32;
 
-        // Only check for a preceding jump if the sub-program has at least two instructions.
-        if (end_index >= start_index + 2) {
+        // An unconditional jump as the penultimate instruction.
+        if (!ends_with_exit && !ends_with_jump && end_index >= start_index + 2) {
             ends_with_jump = insts[end_index - 2].opcode == EBPF_OP_JA ||
                              insts[end_index - 2].opcode == EBPF_OP_JA32;
         }


### PR DESCRIPTION
Note from me, the human: this is mostly AI, but I've spent a few days making sure it's correct and adversarially reviewing these to make sure they're upstream worthy. They fix all of the problems I've been having – I can follow up with minimal reproductions if you'd feel more comfortable.

--

This series fixes four places where uBPF's loader and verifier made assumptions about clang/LLVM output that do not
hold in practice. Each is an independent fix; they are grouped here because three of them touch the R_BPF_64_64
relocation path in vm/ubpf_loader.c.

verifier: accept sub-programs that end in an unconditional jump
check_for_self_contained_sub_programs only accepted a local-call sub-program ending in EXIT or with an unconditional
jump as its penultimate instruction. clang can lay out a function whose tail is a loop back-edge (every exit goes
through an EXIT in the loop body, last instruction is a JA to the top), which was rejected. Accepts a trailing JA/JA32
as a terminator. Adds positive and negative test fixtures.

Recompute un-relocated intra-section bpf-to-bpf call targets after link
clang emits calls between static functions in the same section with a PC-relative imm and no relocation entry,
computed against the .o layout. The loader lands functions in symbol-table order, so the imm is stale whenever that
order differs from .o order (notably when the main function is not first in its section). Adds a post-link pass that
recomputes these calls from landed positions, skipping call sites that already carry a relocation. Adds a custom test.

loader: accept allocated non-executable PROGBITS sections as R_BPF_64_64 targets
The relocation gate required sh_flags to equal exactly (SHF_ALLOC | SHF_WRITE), so it accepted only .data and rejected
.rodata / .rodata.str* (read-only globals and string literals). Switches to a flag mask that accepts allocated
PROGBITS while excluding SHF_EXECINSTR, so .text cannot be used as a data relocation target. Also tightens an adjacent
section-index bound and makes the symbol-size check overflow-safe.

Fold REL addend into data relocation offset and bound it
For merged-string sections, clang relocates each LDDW against the section symbol (st_value == 0) and stores the
per-literal offset in the instruction imm, since BPF uses REL relocations rather than RELA. The loader dropped that
imm, so every literal in a merged section resolved to the same host pointer. Folds the imm into symbol_offset for
section-symbol relocations and bounds the result against the section size.