### PR TITLE
ci: fix macOS coverage jobs broken by Homebrew tap-trust policy

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -279,6 +279,11 @@ jobs:
     - name: Coveralls Parallel
       if: inputs.enable_coverage == true
       uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+      env:
+        # On macOS the action installs its reporter via `brew install coverallsapp/coveralls/coveralls`.
+        # Homebrew's tap-trust policy refuses to load that formula, failing the step. Opt out of the
+        # trust prompt for this install. No effect on Linux, where the reporter is fetched directly.
+        HOMEBREW_NO_REQUIRE_TAP_TRUST: "1"
       with:
         github-token: ${{ secrets.github_token }}
         flag-name: run-${{inputs.build_type}}-${{inputs.platform}}-${{inputs.arch}}


### PR DESCRIPTION
## Problem

All four macOS coverage jobs (macos_release_coverage, macos_release_coverage_no_retpolines, macos_debug_coverage, macos_debug_coverage_no_retpolines) fail. They do not fail in uBPF's build or tests; they fail at the "Coveralls Parallel" step.

On macOS the coverallsapp/github-action installs its reporter with `brew install coverallsapp/coveralls/coveralls`. Homebrew recently started enforcing a tap-trust policy that refuses to load a formula from an untrusted tap:

```
Error: Refusing to load formula coverallsapp/coveralls/coveralls from untrusted tap coverallsapp/coveralls.
Run `brew trust --formula coverallsapp/coveralls/coveralls` or `brew trust coverallsapp/coveralls` to trust it.
```

This affects every PR, not just one branch (for example it is visible on the CI for #801 after it merged to main), because the failing step runs after the tests succeed and is independent of the diff.

## Fix

Set `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` on the Coveralls step so the reporter installs without the trust prompt.

- Scoped to that single step, so it does not relax tap-trust for anything else on the runner.
- No-op on Linux, where the action fetches the reporter without Homebrew.
- One added env block, no logic change.

## Verification

Reproduced and fixed locally on macOS (arm64, Homebrew):

1. Reproduced the exact CI error: `brew install coverallsapp/coveralls/coveralls` fails with the tap-trust refusal above.
2. Confirmed the fix: `HOMEBREW_NO_REQUIRE_TAP_TRUST=1 brew install coveralls` installs cleanly and the binary lands at `/opt/homebrew/bin/coveralls`, where the action expects it.
3. Confirmed uBPF is otherwise healthy on macOS: configured with the same flags the coverage job uses (RelWithDebInfo, UBPF_ENABLE_COVERAGE=true, tests on), built clean, and the full suite passed (1272/1272 tests).

## Notes

The stricter alternative is an explicit `brew trust coverallsapp/coveralls` step, but the action controls the install invocation, so the env var is the smaller and more direct lever.