### PR TITLE
Fix MSVC C4146 in EBPF_OP_NEG64 interpreter handler

### DIFF
--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -1171,7 +1171,7 @@ ubpf_exec_ex(
             reg[inst.dst] >>= SHIFT_MASK_64_BIT(reg[inst.src]);
             break;
         case EBPF_OP_NEG64:
-            reg[inst.dst] = -(int64_t)reg[inst.dst];
+            reg[inst.dst] = 0 - reg[inst.dst];
             break;
         case EBPF_OP_MOD64_IMM:
             if (inst.offset == 0) {

--- a/vm/ubpf_vm.c
+++ b/vm/ubpf_vm.c
@@ -1171,7 +1171,7 @@ ubpf_exec_ex(
             reg[inst.dst] >>= SHIFT_MASK_64_BIT(reg[inst.src]);
             break;
         case EBPF_OP_NEG64:
-            reg[inst.dst] = -reg[inst.dst];
+            reg[inst.dst] = -(int64_t)reg[inst.dst];
             break;
         case EBPF_OP_MOD64_IMM:
             if (inst.offset == 0) {


### PR DESCRIPTION
## Problem

The 64-bit negation handler `EBPF_OP_NEG64` in the interpreter applies unary minus directly to the unsigned `reg[inst.dst]` (`uint64_t`):

```c
case EBPF_OP_NEG64:
    reg[inst.dst] = -reg[inst.dst];
    break;
```

MSVC flags this as **C4146** ("unary minus operator applied to unsigned type, result still unsigned"). This was surfaced by a Microsoft MSVC security scan (TSA) against the vendored copy of ubpf in the [microsoft/ebpf-for-windows](https://github.com/microsoft/ebpf-for-windows) submodule.

## Fix

Perform the negation in unsigned arithmetic:

```c
case EBPF_OP_NEG64:
    reg[inst.dst] = 0 - reg[inst.dst];
    break;
```

Subtraction on `uint64_t` is well-defined two's-complement negation modulo 2^64, which is exactly what BPF `NEG64` is defined to do, so runtime behavior is unchanged. Because C4146 is specific to the *unary* minus operator, the binary `0 - x` form also resolves the warning.

### Why not `-(int64_t)reg[inst.dst]`?

An earlier revision cast to `int64_t` before negating. That introduces signed-integer-overflow undefined behavior for the reachable input `0x8000000000000000` (`INT64_MIN`), since negating `INT64_MIN` overflows. Keeping the operation in unsigned arithmetic avoids any signed overflow / implementation-defined conversion while still clearing the warning.