### PR TITLE
libfuzzer: seed verifier thread-local state

### DIFF
--- a/libfuzzer/libfuzz_harness.cc
+++ b/libfuzzer/libfuzz_harness.cc
@@ -398,7 +398,11 @@ try {
     auto result = std::make_shared<prevail::AnalysisResult>();
     auto verification_completed = std::make_shared<bool>(false);
 
-    std::thread verification_thread([program, result, verification_completed, result_promise]() {
+    std::thread verification_thread([program, result, verification_completed, result_promise, info]() {
+        // Prevail caches program metadata in thread-local storage, so each worker thread must seed its own copy
+        // before running analysis.
+        prevail::thread_local_program_info.set(info);
+
         auto safe_set_value = [&result_promise](bool value) {
             try {
                 result_promise->set_value(value);


### PR DESCRIPTION
## Summary
- seed Prevail thread-local program info inside the verifier timeout worker thread
- preserve the existing timeout-based verifier isolation without dereferencing null thread-local state
- fixes the fuzzing workflow crash reproduced by seed \\CAAAAJUAAAAAAAAA\\`n
## Testing
- build uzzing-windows-vs2026 ubpf_fuzzer
- run ubpf_fuzzer with UBPF_FUZZER_CONSTRAINT_CHECK=1 against the crashing seed