### PR TITLE
libfuzzer: seed verifier options thread-local state

### DIFF
--- a/libfuzzer/libfuzz_harness.cc
+++ b/libfuzzer/libfuzz_harness.cc
@@ -398,10 +398,11 @@ try {
     auto result = std::make_shared<prevail::AnalysisResult>();
     auto verification_completed = std::make_shared<bool>(false);
 
-    std::thread verification_thread([program, result, verification_completed, result_promise, info]() {
-        // Prevail caches program metadata in thread-local storage, so each worker thread must seed its own copy
-        // before running analysis.
+    std::thread verification_thread([program, result, verification_completed, result_promise, info, options]() {
+        // Prevail caches both program metadata and verifier options in thread-local storage, so each worker thread must
+        // seed its own copies before running analysis.
         prevail::thread_local_program_info.set(info);
+        prevail::thread_local_options = options;
 
         auto safe_set_value = [&result_promise](bool value) {
             try {


### PR DESCRIPTION
## Summary
- seed Prevail''s verifier options thread-local alongside ProgramInfo in the timeout worker thread
- keep worker-thread analysis behavior aligned with the configured termination-checking options
- prevent the Windows fuzz seed EAAAAL8UAAAAAAAABgAAAP7///8= from reaching interpreter instruction-limit failure

## Testing
- rebuild ubpf_fuzzer in the fuzzing-windows-vs2026 configuration
- run ubpf_fuzzer -runs=1 against the Windows repro seed